### PR TITLE
modules (nextcloud): declarative configuration for richdocuments

### DIFF
--- a/modules/nixos/nextcloud/richdocuments.nix
+++ b/modules/nixos/nextcloud/richdocuments.nix
@@ -34,7 +34,7 @@
         else "https://collabora.${config.my.host.name}.ritter.family";
       postStart = pkgs.writeShellScriptBin "nextcloud-declarative-config" ''
         set -euo pipefail
-        CONTAINER_IP=`${pkgs.docker} container inspect -f '{{ .NetworkSettings.IPAddress }}' collabora-code`
+        CONTAINER_IP=`${pkgs.docker}/bin/docker container inspect -f '{{ .NetworkSettings.IPAddress }}' collabora-code`
         ${occ} config:app:set --value "${codeUrl}" richdocuments wopi_url
         ${occ} config:app:set --value "$CONTAINER_IP" richdocuments wopi_allowlist
       '';

--- a/modules/nixos/nextcloud/richdocuments.nix
+++ b/modules/nixos/nextcloud/richdocuments.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: {
   config = lib.mkIf config.services.nextcloud.enable {
@@ -25,9 +26,22 @@
       };
     };
 
-    systemd.services.nginx = {
+    systemd.services.nginx = let
+      occ = "${config.services.nextcloud.occ}/bin/nextcloud-occ";
+      codeUrl =
+        if config.my.host.name == "srv-prod-2"
+        then "https://collabora.ritter.family"
+        else "https://collabora.${config.my.host.name}.ritter.family";
+      postStart = pkgs.writeShellScriptBin "nextcloud-declarative-config" ''
+        CONTAINER_IP=`docker container inspect -f '{{ .NetworkSettings.IPAddress }}' collabora-code`
+        ${occ} config:app:set --value "${codeUrl}" richdocuments wopi_url
+        ${occ} config:app:set --value "${codeUrl}" richdocuments public_wopi_url
+        ${occ} config:app:set --value "$CONTAINER_IP" richdocuments wopi_allowlist
+      '';
+    in {
       after = ["docker-collabora-code.service"];
       requires = ["docker-collabora-code.service"];
+      serviceConfig.ExecPostStart = "+${postStart}/bin/nextcloud-declarative-config";
     };
 
     my.modules.https-proxy = {

--- a/modules/nixos/nextcloud/richdocuments.nix
+++ b/modules/nixos/nextcloud/richdocuments.nix
@@ -41,7 +41,7 @@
     in {
       after = ["docker-collabora-code.service"];
       requires = ["docker-collabora-code.service"];
-      serviceConfig.ExecPostStart = "+${postStart}/bin/nextcloud-declarative-config";
+      serviceConfig.ExecStartPost = "+${postStart}/bin/nextcloud-declarative-config";
     };
 
     my.modules.https-proxy = {

--- a/modules/nixos/nextcloud/richdocuments.nix
+++ b/modules/nixos/nextcloud/richdocuments.nix
@@ -33,7 +33,7 @@
         then "https://collabora.ritter.family"
         else "https://collabora.${config.my.host.name}.ritter.family";
       postStart = pkgs.writeShellScriptBin "nextcloud-declarative-config" ''
-        CONTAINER_IP=`docker container inspect -f '{{ .NetworkSettings.IPAddress }}' collabora-code`
+        CONTAINER_IP=`${pkgs.docker} container inspect -f '{{ .NetworkSettings.IPAddress }}' collabora-code`
         ${occ} config:app:set --value "${codeUrl}" richdocuments wopi_url
         ${occ} config:app:set --value "${codeUrl}" richdocuments public_wopi_url
         ${occ} config:app:set --value "$CONTAINER_IP" richdocuments wopi_allowlist

--- a/modules/nixos/nextcloud/richdocuments.nix
+++ b/modules/nixos/nextcloud/richdocuments.nix
@@ -33,9 +33,9 @@
         then "https://collabora.ritter.family"
         else "https://collabora.${config.my.host.name}.ritter.family";
       postStart = pkgs.writeShellScriptBin "nextcloud-declarative-config" ''
+        set -euo pipefail
         CONTAINER_IP=`${pkgs.docker} container inspect -f '{{ .NetworkSettings.IPAddress }}' collabora-code`
         ${occ} config:app:set --value "${codeUrl}" richdocuments wopi_url
-        ${occ} config:app:set --value "${codeUrl}" richdocuments public_wopi_url
         ${occ} config:app:set --value "$CONTAINER_IP" richdocuments wopi_allowlist
       '';
     in {


### PR DESCRIPTION
Configures an `ExecStartPost` script for the nginx systemd unit that sets two
relevant configuration values for the richdocuments app:

- wopi_url is set to the DNS name for collabora
- wopi_allowlist is set to the IP address of the collabora docker container