### PR TITLE
flake: Base config on nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -180,16 +180,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1755928099,
-        "narHash": "sha256-OILVkfhRCm8u18IZ2DKR8gz8CVZM2ZcJmQBXmjFLIfk=",
+        "lastModified": 1756022458,
+        "narHash": "sha256-J1i35r4HfNDdPpwL0vOBaZopQudAUVtartEerc1Jryc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4a44fb9f7555da362af9d499817084f4288a957f",
+        "rev": "9e3a33c0bcbc25619e540b9dfea372282f8a9740",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -269,7 +268,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1755615617,
         "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
@@ -281,22 +280,6 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1755922037,
-        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -343,16 +326,15 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1755727480,
-        "narHash": "sha256-eb9N7XFj1zirk+D2KV+rn/CjmVHDISlxhtZCWZEVpkM=",
+        "lastModified": 1756123127,
+        "narHash": "sha256-Xe3Xt76SL5cnMFIKrZcbo4ysh+bm76WFagsDYKK7P7s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6df0b97b39baa1c0b3002b051f307aed68e17d1b",
+        "rev": "9f036a41d3cd2be5ebc5cd24786299ee974f66e2",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "nixos-25.05",
         "repo": "nixvim",
         "type": "github"
       }
@@ -431,7 +413,6 @@
         "nixos-facter-modules": "nixos-facter-modules",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvim": "nixvim",
         "nur": "nur",
         "pre-commit-hooks": "pre-commit-hooks",

--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,14 @@
     };
     flake-utils.url = "github:numtide/flake-utils";
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.05";
+      url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nixos-facter-modules.url = "github:numtide/nixos-facter-modules";
     nixos-hardware.url = "github:nixos/nixos-hardware/master";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixvim = {
-      url = "github:nix-community/nixvim/nixos-25.05";
+      url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nur.url = "github:nix-community/NUR";
@@ -47,7 +46,6 @@
       system:
       let
         pkgs = inputs.nixpkgs.legacyPackages.${system};
-        pkgs-unstable = inputs.nixpkgs-unstable.legacyPackages.${system};
         my-pkgs = self.outputs.packages.${system};
         treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
       in
@@ -65,7 +63,6 @@
         };
         packages = import ./packages { inherit pkgs; };
         overlays = import ./overlays {
-          inherit pkgs-unstable;
           inherit my-pkgs;
           inherit (inputs) nur;
         };
@@ -89,7 +86,7 @@
         # the path to your home.nix.
         modules = [
           inputs.catppuccin.homeModules.catppuccin
-          inputs.nixvim.homeManagerModules.nixvim
+          inputs.nixvim.homeModules.nixvim
           ./home/benedikt.nix
           (
             { pkgs, lib, ... }:

--- a/home/desktop/browser/librewolf.nix
+++ b/home/desktop/browser/librewolf.nix
@@ -25,7 +25,6 @@ in
         DisableTelemetry = true;
         DisableFirefoxAccounts = false;
         DisplayBookmarksToolbar = "newtab";
-        NoDefaultBookmarks = true;
         OfferToSaveLogins = false;
         OfferToSaveLoginsDefault = false;
         PasswordManagerEnabled = false;

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -22,7 +22,7 @@ in
         home.stateVersion = "23.05";
         imports = [
           inputs.catppuccin.homeModules.catppuccin
-          inputs.nixvim.homeManagerModules.nixvim
+          inputs.nixvim.homeModules.nixvim
           ../../home
         ];
       };

--- a/modules/sway/default.nix
+++ b/modules/sway/default.nix
@@ -35,15 +35,14 @@ in
     services = {
       greetd = {
         enable = true;
-        vt = 2;
         settings = {
           default_session = {
             command = ''
-              ${pkgs.greetd.tuigreet}/bin/tuigreet \
+              ${lib.getExe pkgs.tuigreet} \
                 --remember \
                 --time \
                 --asterisks \
-                --cmd ${pkgs.sway}/bin/sway
+                --cmd ${lib.getExe pkgs.sway}
             '';
           };
         };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,11 +1,5 @@
 {
-  pkgs-unstable,
   my-pkgs,
   nur,
 }:
-_final: _prev:
-{
-  inherit (pkgs-unstable) jetbrains;
-}
-// my-pkgs
-// (nur.overlays.default _final _prev)
+_final: _prev: my-pkgs // (nur.overlays.default _final _prev)

--- a/overlays/packages-from-unstable/default.nix
+++ b/overlays/packages-from-unstable/default.nix
@@ -1,4 +1,0 @@
-{ pkgs-unstable, ... }:
-_final: _prev: {
-  inherit (pkgs-unstable) jetbrains;
-}


### PR DESCRIPTION
Instead of the latest stable release, the config is now based on nixos-unstable. While this might require fixing deprecations more frequently, there won't be a need for a big migration when a new nixos release happens. Furthermore I get the most recent packages and don't have to wait half a year in case package major releases can't be backported from unstable to stable.