### PR TITLE
jfmt: fix reproducibility issues

### DIFF
--- a/packages/jfmt-java/default.nix
+++ b/packages/jfmt-java/default.nix
@@ -19,7 +19,7 @@ maven_4.buildMavenPackage {
     rev = "9870374e6cf6b8e5f2142eafee1b8b671797ee92";
     sha256 = "sha256-RJHYiW31oZp86IohPfoBbX7GSp6teuCTJgjZmQ9EzKQ=";
   };
-  mvnHash = "sha256-DmYrO+aeNeakiIl0jTqgaKDCIkbkTHDtVsk9xE3yegs=";
+  mvnHash = "sha256-q3d1cCt7c0thNSRjRDBPtTRWsrPc/ArQltil4yeU0j0=";
   patches = [ ./0001-drop-JReleaser-from-build.patch ];
 
   mvnJdk = jdk25_headless;

--- a/packages/maven_4/build-maven-package.nix
+++ b/packages/maven_4/build-maven-package.nix
@@ -1,0 +1,167 @@
+{
+  lib,
+  stdenv,
+  jdk,
+  jre-generate-cacerts,
+  maven,
+  writers,
+}:
+let
+  buildMavenPackage =
+    {
+      src,
+      sourceRoot ? null,
+      buildOffline ? false,
+      doCheck ? true,
+      prePatch ? null,
+      patches ? [ ],
+      postPatch ? null,
+      pname,
+      version,
+      mvnJdk ? jdk,
+      mvnHash ? "",
+      mvnFetchExtraArgs ? { },
+      mvnDepsParameters ? "",
+      manualMvnArtifacts ? [ ],
+      manualMvnSources ? [ ],
+      mvnParameters ? "",
+      ...
+    }@args:
+
+    # originally extracted from dbeaver
+    # created to allow using maven packages in the same style as rust
+
+    let
+      mvnSkipTests = lib.optionalString (!doCheck) "-DskipTests";
+
+      writeProxySettings = writers.writePython3 "write-proxy-settings" { } ./maven-proxy.py;
+
+      fetchedMavenDeps = stdenv.mkDerivation (
+        {
+          pname = "maven-deps-${pname}";
+          inherit
+            src
+            sourceRoot
+            prePatch
+            patches
+            postPatch
+            version
+            ;
+
+          nativeBuildInputs = [
+            maven
+          ]
+          ++ args.nativeBuildInputs or [ ];
+
+          env = mvnFetchExtraArgs.env or { } // {
+            JAVA_HOME = mvnJdk;
+          };
+
+          impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
+          buildPhase = ''
+            runHook preBuild
+
+            MAVEN_EXTRA_ARGS="-B"
+
+            # handle proxy
+            if [[ -n "''${HTTP_PROXY-}" ]] || [[ -n "''${HTTPS_PROXY-}" ]] || [[ -n "''${NO_PROXY-}" ]];then
+              mvnSettingsFile="$(mktemp -d)/settings.xml"
+              ${writeProxySettings} $mvnSettingsFile
+              MAVEN_EXTRA_ARGS="$MAVEN_EXTRA_ARGS -s=$mvnSettingsFile"
+            fi
+
+            # handle cacert by populating a trust store on the fly
+            if [[ -n "''${NIX_SSL_CERT_FILE-}" ]] && [[ "''${NIX_SSL_CERT_FILE-}" != "/no-cert-file.crt" ]];then
+              echo "using ''${NIX_SSL_CERT_FILE-} as trust store"
+              ${jre-generate-cacerts} ${lib.getBin jdk}/bin/keytool $NIX_SSL_CERT_FILE
+
+              MAVEN_EXTRA_ARGS="$MAVEN_EXTRA_ARGS -Djavax.net.ssl.trustStore=cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+            fi
+          ''
+          + lib.optionalString buildOffline ''
+            mvn $MAVEN_EXTRA_ARGS de.qaware.maven:go-offline-maven-plugin:1.2.8:resolve-dependencies -Dmaven.repo.local=$out/.m2 ${mvnDepsParameters}
+
+            for artifactId in ${toString manualMvnArtifacts}
+            do
+              echo "downloading manual $artifactId"
+              mvn $MAVEN_EXTRA_ARGS dependency:get -Dartifact="$artifactId" -Dmaven.repo.local=$out/.m2
+            done
+
+            for artifactId in ${toString manualMvnSources}
+            do
+              group=$(echo $artifactId | cut -d':' -f1)
+              artifact=$(echo $artifactId | cut -d':' -f2)
+              echo "downloading manual sources $artifactId"
+              mvn $MAVEN_EXTRA_ARGS dependency:sources -DincludeGroupIds="$group" -DincludeArtifactIds="$artifact" -Dmaven.repo.local=$out/.m2
+            done
+          ''
+          + lib.optionalString (!buildOffline) ''
+            mvn $MAVEN_EXTRA_ARGS package -Dmaven.repo.local=$out/.m2 ${mvnSkipTests} ${mvnParameters}
+          ''
+          + ''
+            runHook postBuild
+          '';
+
+          # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+          installPhase = ''
+            runHook preInstall
+
+            find $out -type f \( \
+              -name \*.lastUpdated \
+              -o -name resolver-status.properties \
+              -o -name _remote.repositories \) \
+              -delete
+            # Remove Equo/p2 cache which contains timestamps and absolute paths
+            rm -rf $out/dev/equo/p2-data/metadata/connection
+            rm -rf $out/dev/equo/p2-data/queries
+
+            runHook postInstall
+          '';
+
+          # don't do any fixup
+          dontFixup = true;
+          outputHashAlgo = if mvnHash != "" then null else "sha256";
+          outputHashMode = "recursive";
+          outputHash = mvnHash;
+        }
+        // (removeAttrs mvnFetchExtraArgs [ "env" ])
+      );
+    in
+    stdenv.mkDerivation (
+      removeAttrs args [ "mvnFetchExtraArgs" ]
+      // {
+        inherit fetchedMavenDeps;
+
+        nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
+          maven
+        ];
+
+        env = args.env or { } // {
+          JAVA_HOME = mvnJdk;
+        };
+
+        buildPhase = ''
+          runHook preBuild
+
+          mvnDeps=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)
+          runHook afterDepsSetup
+          mvn package -o -nsu "-Dmaven.repo.local=$mvnDeps/.m2" ${mvnSkipTests} ${mvnParameters}
+
+          runHook postBuild
+        '';
+
+        meta = args.meta or { } // {
+          platforms = args.meta.platforms or maven.meta.platforms;
+        };
+      }
+    );
+in
+fnOrAttrs:
+if !lib.isFunction fnOrAttrs then
+  buildMavenPackage fnOrAttrs
+else
+  let
+    finalAttrs = fnOrAttrs finalAttrs;
+  in
+  buildMavenPackage finalAttrs

--- a/packages/maven_4/default.nix
+++ b/packages/maven_4/default.nix
@@ -1,6 +1,7 @@
 {
   fetchurl,
   maven,
+  callPackage,
 }:
 maven.overrideAttrs (
   final: _prev: {
@@ -8,6 +9,9 @@ maven.overrideAttrs (
     src = fetchurl {
       url = "mirror://apache/maven/maven-4/${final.version}/binaries/apache-maven-${final.version}-bin.tar.gz";
       hash = "sha256-7OalyZ09BBx25/7RgU656jogoSC8s8I1pz0sTo2xbKE=";
+    };
+    passthru.buildMavenPackage = callPackage ./build-maven-package.nix {
+      maven = final.finalPackage;
     };
   }
 )

--- a/packages/maven_4/maven-proxy.py
+++ b/packages/maven_4/maven-proxy.py
@@ -1,0 +1,86 @@
+"""
+Maven doesn't honor HTTP[S]_PROXY and NO_PROXY env vars out of the box.
+Instead, it expects the user to configure a settings.xml file.
+We however impurely pass only these env vars in FODs.
+This creates the XML file on demand, if one or more env vars is set.
+"""
+
+import os
+import sys
+from urllib.parse import urlparse
+
+
+def parse_proxy_url(url):
+    if url is None:
+        return None
+    parsed = urlparse(url)
+
+    if parsed.hostname is None:
+        print(f"Failed to parse proxy URL {url}, ignoring", file=sys.stderr)
+        return None
+
+    return {
+        'protocol': parsed.scheme or 'http',
+        'host': parsed.hostname,
+        'port': parsed.port or (443 if parsed.scheme == 'https' else 80),
+        'username': parsed.username,
+        'password': parsed.password
+    }
+
+
+def format_proxy_block(proxy, id_suffix, non_proxy_hosts):
+    auth = ""
+    if proxy.get("username"):
+        auth += f"    <username>{proxy['username']}</username>\n"
+    if proxy.get("password"):
+        auth += f"    <password>{proxy['password']}</password>\n"
+
+    np_hosts = ""
+    if non_proxy_hosts:
+        np_hosts = f"    <nonProxyHosts>{non_proxy_hosts}</nonProxyHosts>\n"
+
+    return f"""  <proxy>
+    <id>{id_suffix}-proxy</id>
+    <active>true</active>
+    <protocol>{proxy['protocol']}</protocol>
+    <host>{proxy['host']}</host>
+    <port>{proxy['port']}</port>
+{auth}{np_hosts}  </proxy>"""
+
+
+def main(output_path):
+    http_proxy = parse_proxy_url(os.environ.get("HTTP_PROXY"))
+    https_proxy = parse_proxy_url(os.environ.get("HTTPS_PROXY"))
+    non_proxy_hosts = os.environ.get("NO_PROXY", "").replace(",", "|")
+
+    proxy_blocks = []
+
+    if http_proxy:
+        proxy_blocks.append(
+          format_proxy_block(http_proxy, "http", non_proxy_hosts)
+        )
+    if https_proxy and https_proxy != http_proxy:
+        proxy_blocks.append(
+          format_proxy_block(https_proxy, "https", non_proxy_hosts)
+        )
+
+    settings_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                  http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <proxies>
+{'\n'.join(proxy_blocks)}
+  </proxies>
+</settings>
+"""
+
+    with open(output_path, "w") as f:
+        f.write(settings_xml)
+
+    print(f"Generated Maven settings.xml at {output_path}")
+
+
+if __name__ == "__main__":
+    output_file = sys.argv[1] if len(sys.argv) > 1 else "settings.xml"
+    main(output_file)


### PR DESCRIPTION
It turns out the reproducibility issues in jfmt are not related to
jreleaser, but to the fact that the m2 repository captured for the
dependency FOD changes between rebuilds. This is due to Equo
(https://equo.dev) being used as a dependency. Equo uses p2 under the
hood and write changing files to m2, in particular:

- OkHttp cache files located in dev/equo/p2-data/metadata/connection/*.0
- p2 cache files located in dev/equo/p2-data/queries/.../content

Since the upstream buildMavenPackage builder uses a deny list for files in
m2, everything that's not part of that deny list will pass into the FOD
and influence the FOD's hash.

Since there is no way modify that filter, this change copies
buildMavenPackage into this repository and overrides it for maven_4 with
the appropriate filter.
