### PR TITLE
overlays: lift out of per-system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
       system:
       let
         pkgs = inputs.nixpkgs.legacyPackages.${system};
-        my-pkgs = self.outputs.packages.${system};
         treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
       in
       {
@@ -66,10 +65,6 @@
           formatting = treefmtEval.config.build.check self;
         };
         packages = import ./packages { inherit pkgs; };
-        overlays = import ./overlays {
-          inherit my-pkgs;
-          inherit (inputs) nur;
-        };
         devShells.default = pkgs.mkShell {
           inherit (self.checks.${system}.pre-commit-check) shellHook;
           buildInputs = self.checks.${system}.pre-commit-check.enabledPackages;
@@ -80,6 +75,9 @@
         };
       }
     )
+    // {
+      overlays.default = import ./overlays { inherit (inputs) nur; };
+    }
     // {
       templates = {
         minimalDevShell = {
@@ -96,24 +94,15 @@
           inputs.catppuccin.homeModules.catppuccin
           inputs.nixvim.homeModules.nixvim
           ./home/benedikt.nix
-          (
-            { pkgs, ... }:
-            {
-              nixpkgs.overlays = [
-                (_self: _super: rec {
-                  gh-get = pkgs.callPackage ./packages/gh-get { };
-                  jfmt-java = pkgs.callPackage ./packages/jfmt-java { inherit maven_4; };
-                  maven_4 = pkgs.callPackage ./packages/maven_4 { };
-                  kotlin-lsp = pkgs.callPackage ./packages/kotlin-lsp { };
-                })
-              ];
-              nixpkgs.config.allowUnfreePackages = [
-                "terraform"
-                "claude-code"
-              ];
-
-            }
-          )
+          (_: {
+            nixpkgs.overlays = [
+              inputs.self.overlays.default
+            ];
+            nixpkgs.config.allowUnfreePackages = [
+              "terraform"
+              "claude-code"
+            ];
+          })
         ];
 
         extraSpecialArgs = {

--- a/modules/nix/default.nix
+++ b/modules/nix/default.nix
@@ -1,11 +1,7 @@
 {
-  config,
   inputs,
   ...
 }:
-let
-  inherit (config.my.host) system;
-in
 {
   config = {
     nix = {
@@ -23,6 +19,6 @@ in
       };
     };
 
-    nixpkgs.overlays = [ inputs.self.overlays.${system} ];
+    nixpkgs.overlays = [ inputs.self.overlays.default ];
   };
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,9 +1,8 @@
 {
-  my-pkgs,
   nur,
 }:
 final: prev:
-my-pkgs
+(import ../packages { pkgs = final; })
 // (nur.overlays.default final prev)
 // {
   calibre-web = prev.calibre-web.overrideAttrs (prev: {

--- a/overlays/my-pkgs/default.nix
+++ b/overlays/my-pkgs/default.nix
@@ -1,1 +1,0 @@
-{ my-pkgs, ... }: _final: _prev: my-pkgs


### PR DESCRIPTION
Previously overlays where set up per system because I instantiated
`my-pkgs` in the per systems block without realizing that the overlay
function receives pkgs parameters via its final and prev arguments.
Using the final parameter to instantiate my packages allows to lift
overlays out of per system which at the same time allows reusing it more
easily for standalone config.
