### PR TITLE
ci-build: cover directions on an ARM runner

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -7,20 +7,26 @@ on:
     branches: ["main"]
 
 jobs:
-  build-x86:
-    name: Build x86 systems
-    runs-on: ubuntu-latest
+  build-system:
+    name: Build system
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        configuration:
-          [
-            "framework-13",
-            "srv-prod-2",
-            "srv-prod-3",
-            "srv-prod-4",
-            "srv-prod-5",
-            "srv-offsite-1",
-          ]
+        include:
+          - configuration: framework-13
+            runner: ubuntu-latest
+          - configuration: srv-prod-2
+            runner: ubuntu-latest
+          - configuration: srv-prod-3
+            runner: ubuntu-latest
+          - configuration: srv-prod-4
+            runner: ubuntu-latest
+          - configuration: srv-prod-5
+            runner: ubuntu-latest
+          - configuration: srv-offsite-1
+            runner: ubuntu-latest
+          - configuration: directions
+            runner: ubuntu-24.04-arm
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main


### PR DESCRIPTION
Combines the previous build-x86 job into a single build-system
matrix that pairs each configuration with its runner via matrix
include. directions now builds on ubuntu-24.04-arm; the x86 hosts
keep building on ubuntu-latest. Adding a new host of either
architecture is a single matrix entry.
