### PR TITLE
lib: drop inputs specialArgs from mkNixos and mkHomeManager

### DIFF
--- a/_needs_migration/modules/default.nix
+++ b/_needs_migration/modules/default.nix
@@ -11,7 +11,6 @@
     ./minio
     ./navidrome
     ./nextcloud
-    ./nix
     ./restic-restore
     ./stirling-pdf
     ./tailscale

--- a/modules/nix/dev-shell/dev-shell.nix
+++ b/modules/nix/dev-shell/dev-shell.nix
@@ -1,6 +1,7 @@
 { inputs, config, ... }:
 let
   inherit (config.flake.lib) relativePath;
+  inherit (config.flake) nixosConfigurations;
 in
 {
   imports = [ inputs.pre-commit-hooks.flakeModule ];
@@ -25,7 +26,7 @@ in
               pkgs.git
             ];
             runtimeEnv = {
-              CONFIGURATIONS = lib.pipe inputs.self.nixosConfigurations [
+              CONFIGURATIONS = lib.pipe nixosConfigurations [
                 lib.attrNames
                 (lib.filter (lib.hasPrefix "srv"))
                 (lib.concatStringsSep " ")

--- a/modules/nix/lib.nix
+++ b/modules/nix/lib.nix
@@ -11,9 +11,8 @@
     relativePath = path: lib.removePrefix "${inputs.self}/" (toString path);
     mkNixos = system: name: {
       ${name} = inputs.nixpkgs.lib.nixosSystem {
-        specialArgs = { inherit inputs; };
         modules = [
-          inputs.self.modules.nixos.${name}
+          config.flake.modules.nixos.${name}
           {
             networking.hostName = name;
             nixpkgs.hostPlatform = lib.mkDefault system;
@@ -25,13 +24,12 @@
       ${name} = inputs.home-manager.lib.homeManagerConfiguration {
         pkgs = import inputs.nixpkgs {
           inherit system;
-          overlays = [ inputs.self.overlays.default ];
+          overlays = [ config.flake.overlays.default ];
           config.allowUnfreePackages = config.flake.allowUnfreePackages;
         };
         modules = [
-          inputs.self.modules.homeManager.${name}
+          config.flake.modules.homeManager.${name}
         ];
-        extraSpecialArgs = { inherit inputs; };
       };
     };
   };

--- a/modules/nix/overlays.nix
+++ b/modules/nix/overlays.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ config, inputs, ... }:
 {
   flake.overlays = {
     local-pkgs = final: _prev: import ../../packages { pkgs = final; };
@@ -17,8 +17,8 @@
     };
 
     default = inputs.nixpkgs.lib.composeManyExtensions [
-      inputs.self.overlays.local-pkgs
-      inputs.self.overlays.fixes
+      config.flake.overlays.local-pkgs
+      config.flake.overlays.fixes
       inputs.nur.overlays.default
     ];
   };

--- a/modules/system/system-types/system-base/nix.nix
+++ b/modules/system/system-types/system-base/nix.nix
@@ -1,9 +1,6 @@
+{ config, ... }:
 {
-  inputs,
-  ...
-}:
-{
-  config = {
+  flake.modules.nixos.system-base = {
     nix = {
       gc = {
         automatic = true;
@@ -19,7 +16,7 @@
       };
     };
 
-    nixpkgs.overlays = [ inputs.self.overlays.default ];
-    nixpkgs.config.allowUnfreePackages = inputs.self.allowUnfreePackages;
+    nixpkgs.overlays = [ config.flake.overlays.default ];
+    nixpkgs.config.allowUnfreePackages = config.flake.allowUnfreePackages;
   };
 }

--- a/modules/users/bene.nix
+++ b/modules/users/bene.nix
@@ -29,7 +29,6 @@ in
       programs.fish.enable = true;
 
       home-manager = {
-        extraSpecialArgs = { inherit inputs; };
         useGlobalPkgs = true;
         useUserPackages = true;
         users.${username}.imports = [ config.flake.modules.homeManager.${username} ];


### PR DESCRIPTION
## Summary

- Promote `_needs_migration/modules/nix/default.nix` content (nix daemon settings, nixpkgs overlay, allowUnfreePackages) to `modules/system/system-types/system-base/nix.nix` as an unnamed contribution. Reaches every host via `system-base`. Replaces `inputs.self.X` accesses with `config.flake.X`. Removes the last consumer of module-arg `inputs`.
- Drop `specialArgs = { inherit inputs; }` from `mkNixos` and `extraSpecialArgs = { inherit inputs; }` from `mkHomeManager` (`modules/nix/lib.nix`). Drop the same from the home-manager bridge in `bene.nix` — the HM body accesses `inputs` via the outer flake-parts closure, not the bridge.
- Sweep remaining `inputs.self.X` references in `lib.nix`, `overlays.nix`, and `dev-shell.nix` to `config.flake.X` — same identity, but `config.flake` is the canonical access path under flake-parts (per mightyiam).