### PR TITLE
nvim: restructure around concerns rather than plugins

### DIFF
--- a/modules/home/nvim/colorscheme.nix
+++ b/modules/home/nvim/colorscheme.nix
@@ -1,0 +1,17 @@
+_: {
+  flake.modules.homeManager.nvim = {
+    programs.nixvim.colorschemes.catppuccin = {
+      enable = true;
+      settings = {
+        flavour = "macchiato";
+        term_colors = true;
+        integrations = {
+          treesitter = true;
+          gitsigns = true;
+          native_lsp.enabled = true;
+          neotree = true;
+        };
+      };
+    };
+  };
+}

--- a/modules/home/nvim/completion.nix
+++ b/modules/home/nvim/completion.nix
@@ -1,95 +1,41 @@
 _: {
   flake.modules.homeManager.nvim = {
-    programs.nixvim = {
-      plugins = {
-        # Review the configuration for cmp after switching to 24.11
-        cmp = {
-          enable = true;
-          autoEnableSources = true;
-          settings = {
-            mapping = {
-              "<C-Space>" = "cmp.mapping.complete()";
-              "<C-n>" = "cmp.mapping.select_next_item { behavior = cmp.SelectBehavior.Insert }";
-              "<C-p>" = "cmp.mapping.select_prev_item { behavior = cmp.SelectBehavior.Insert }";
-              "<C-y>" =
-                # lua
-                ''
-                  cmp.mapping(
-                    cmp.mapping.confirm {
-                      behavior = cmp.ConfirmBehavior.Insert,
-                      select = true,
-                    },
-                    { "i", "c" }
-                  )
-                '';
-            };
-            snippet.expand =
+    programs.nixvim.plugins = {
+      # Review the configuration for cmp after switching to 24.11
+      cmp = {
+        enable = true;
+        autoEnableSources = true;
+        settings = {
+          mapping = {
+            "<C-Space>" = "cmp.mapping.complete()";
+            "<C-n>" = "cmp.mapping.select_next_item { behavior = cmp.SelectBehavior.Insert }";
+            "<C-p>" = "cmp.mapping.select_prev_item { behavior = cmp.SelectBehavior.Insert }";
+            "<C-y>" =
               # lua
               ''
-                function(args)
-                  require('luasnip').lsp_expand(args.body)
-                end
+                cmp.mapping(
+                  cmp.mapping.confirm {
+                    behavior = cmp.ConfirmBehavior.Insert,
+                    select = true,
+                  },
+                  { "i", "c" }
+                )
               '';
-            sources = [
-              { name = "nvim_lsp"; }
-              { name = "luasnip"; }
-              { name = "buffer"; }
-            ];
           };
-        };
-        cmp_luasnip.enable = true;
-        luasnip = {
-          enable = true;
-          fromLua = [
-            {
-              paths = ./snippets;
-            }
+          snippet.expand =
+            # lua
+            ''
+              function(args)
+                require('luasnip').lsp_expand(args.body)
+              end
+            '';
+          sources = [
+            { name = "nvim_lsp"; }
+            { name = "luasnip"; }
+            { name = "buffer"; }
           ];
         };
-        friendly-snippets.enable = true;
       };
-      keymaps = [
-        {
-          action.__raw =
-            # lua
-            ''
-              function()
-                local ls = require "luasnip"
-                if ls.expand_or_jumpable() then
-                  ls.expand_or_jump()
-                end
-              end
-            '';
-          key = "<C-k>";
-          mode = [
-            "i"
-            "s"
-          ];
-          options = {
-            silent = true;
-          };
-        }
-        {
-          action.__raw =
-            # lua
-            ''
-              function()
-                local ls = require "luasnip"
-                if ls.jumpable(-1) then
-                  ls.jump(-1)
-                end
-              end
-            '';
-          key = "<C-j>";
-          mode = [
-            "i"
-            "s"
-          ];
-          options = {
-            silent = true;
-          };
-        }
-      ];
     };
   };
 }

--- a/modules/home/nvim/editor.nix
+++ b/modules/home/nvim/editor.nix
@@ -1,0 +1,59 @@
+_: {
+  flake.modules.homeManager.nvim = {
+    programs.nixvim = {
+      opts = {
+        # Set tab width to 4 spaces (instead of 8)
+        tabstop = 4;
+        # Set how many spaces will be inserted when tab is pressed
+        softtabstop = 2;
+        showtabline = 2;
+        expandtab = true;
+
+        # Enable auto indenting and set it to spaces
+        smartindent = true;
+        shiftwidth = 2;
+
+        # Enable smart indenting (see https://stackoverflow.com/questions/1204149/smart-wrap-in-vim)
+        breakindent = true;
+
+        swapfile = false;
+
+        number = true;
+        relativenumber = true;
+
+        # Enable 24-bit colors
+        termguicolors = true;
+
+        # Enable the sign column to prevent the screen from jumping
+        signcolumn = "yes";
+
+        # Highlight cursor line
+        cursorline = true;
+
+        # Remaining lines visibile before starting to scroll
+        scrolloff = 5;
+
+        list = true;
+        listchars = "tab:→·,lead:·,space:·,trail:~,extends:→,precedes:←,nbsp:␣";
+      };
+      # Show diagnostic as a virtual line but only below the current cursor line
+      diagnostic.settings.virtual_lines.current_line = true;
+      plugins = {
+        nvim-surround.enable = true;
+        sleuth.enable = true;
+      };
+      keymaps = [
+        {
+          action = "<cmd>split<CR>";
+          key = ''<leader>"'';
+          mode = [ "n" ];
+        }
+        {
+          action = "<cmd>vsplit<CR>";
+          key = "<leader>%";
+          mode = [ "n" ];
+        }
+      ];
+    };
+  };
+}

--- a/modules/home/nvim/file-explorer.nix
+++ b/modules/home/nvim/file-explorer.nix
@@ -1,0 +1,25 @@
+_: {
+  flake.modules.homeManager.nvim = {
+    programs.nixvim = {
+      plugins = {
+        neo-tree.enable = true;
+        oil = {
+          enable = true;
+          settings.skip_confirm_for_simple_edits = true;
+        };
+      };
+      keymaps = [
+        {
+          action = "<cmd>Neotree filesystem reveal toggle left<CR>";
+          key = "<C-n>";
+          mode = [ "n" ];
+        }
+        {
+          action = "<cmd>Oil<CR>";
+          key = "-";
+          mode = [ "n" ];
+        }
+      ];
+    };
+  };
+}

--- a/modules/home/nvim/finder.nix
+++ b/modules/home/nvim/finder.nix
@@ -1,0 +1,62 @@
+_: {
+  flake.modules.homeManager.nvim =
+    { lib, pkgs, ... }:
+    {
+      programs.nixvim = {
+        plugins.telescope = {
+          enable = true;
+          extensions.ui-select.enable = true;
+          extensions.fzf-native.enable = true;
+          settings =
+            let
+              rgArgs = [
+                "--hidden"
+                "--glob"
+                "!**/.git/*"
+              ];
+            in
+            {
+              defaults = {
+                vimgrep_arguments = [
+                  (lib.getExe pkgs.ripgrep)
+                  "--color=never"
+                  "--no-heading"
+                  "--with-filename"
+                  "--line-number"
+                  "--column"
+                  "--smart-case"
+                ]
+                ++ rgArgs;
+              };
+              pickers.find_files.find_command = [
+                (lib.getExe pkgs.ripgrep)
+                "--files"
+              ]
+              ++ rgArgs;
+            };
+        };
+        keymaps = [
+          {
+            action = "<cmd>Telescope find_files<CR>";
+            key = "<leader>ff";
+            mode = [ "n" ];
+          }
+          {
+            action = "<cmd>Telescope live_grep<CR>";
+            key = "<leader>fg";
+            mode = [ "n" ];
+          }
+          {
+            action = "<cmd>Telescope buffers<CR>";
+            key = "<leader>fb";
+            mode = [ "n" ];
+          }
+          {
+            action = "<cmd>Telescope help_tags<CR>";
+            key = "<leader>fh";
+            mode = [ "n" ];
+          }
+        ];
+      };
+    };
+}

--- a/modules/home/nvim/formatting.nix
+++ b/modules/home/nvim/formatting.nix
@@ -1,0 +1,67 @@
+_: {
+  flake.modules.homeManager.nvim =
+    { pkgs, ... }:
+    {
+      programs.nixvim.plugins = {
+        none-ls = {
+          enable = true;
+          sources = {
+            formatting = {
+              gofmt.enable = true;
+              nixfmt = {
+                enable = true;
+                package = pkgs.nixfmt;
+              };
+              prettier = {
+                enable = true;
+                # should be removed once https://github.com/nix-community/nixvim/pull/4234 has been merged
+                package = pkgs.prettier;
+                disableTsServerFormatter = true;
+              };
+            };
+            diagnostics.actionlint.enable = true;
+          };
+        };
+        lsp = {
+          luaConfig.pre = ''
+            local augroup = vim.api.nvim_create_augroup('Autoformat', {})
+
+            local function format(buf)
+              local null_ls_sources = require('null-ls.sources')
+              local ft = vim.bo[buf].filetype
+
+              local has_null_ls = #null_ls_sources.get_available(ft, 'NULL_LS_FORMATTING') > 0
+
+              vim.lsp.buf.format({
+                bufnr = buf,
+                filter = function(client)
+                  if has_null_ls then
+                    return client.name == 'null-ls'
+                  else
+                    return true
+                  end
+                end,
+              })
+            end
+          '';
+          onAttach =
+            # lua
+            ''
+              if client.supports_method('textDocument/formatting') then
+                 vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
+                -- Format the current buffer on save
+                vim.api.nvim_create_autocmd('BufWritePre', {
+                  group = augroup;
+                  buffer = bufnr;
+                  callback = function()
+                    if vim.b.format_on_write ~= false then
+                      format(bufnr)
+                    end
+                  end,
+                })
+              end
+            '';
+        };
+      };
+    };
+}

--- a/modules/home/nvim/languages/kotlin.nix
+++ b/modules/home/nvim/languages/kotlin.nix
@@ -1,0 +1,10 @@
+_: {
+  flake.modules.homeManager.nvim =
+    { pkgs, ... }:
+    {
+      programs.nixvim.plugins.lsp.servers.kotlin_lsp = {
+        enable = true;
+        package = pkgs.kotlin-lsp;
+      };
+    };
+}

--- a/modules/home/nvim/languages/log.nix
+++ b/modules/home/nvim/languages/log.nix
@@ -1,0 +1,8 @@
+_: {
+  flake.modules.homeManager.nvim = {
+    programs.nixvim = {
+      filetype.extension.log = "log";
+      files."ftplugin/log.lua".opts.wrap = false;
+    };
+  };
+}

--- a/modules/home/nvim/languages/rust.nix
+++ b/modules/home/nvim/languages/rust.nix
@@ -1,0 +1,12 @@
+_: {
+  flake.modules.homeManager.nvim =
+    { config, ... }:
+    {
+      programs.nixvim.plugins.lsp.servers.rust_analyzer = {
+        enable = config.programs.cargo.enable;
+        installCargo = true;
+        installRustc = true;
+        installRustfmt = true;
+      };
+    };
+}

--- a/modules/home/nvim/lsp.nix
+++ b/modules/home/nvim/lsp.nix
@@ -1,64 +1,55 @@
 _: {
-  flake.modules.homeManager.nvim =
-    { config, pkgs, ... }:
-    {
-      programs.nixvim = {
-        plugins.lsp = {
-          enable = true;
-          inlayHints = true;
-          servers = {
-            astro.enable = true;
-            gopls.enable = true;
-            kotlin_lsp = {
-              enable = true;
-              package = pkgs.kotlin-lsp;
-            };
-            nixd.enable = true;
-            rust_analyzer = {
-              enable = config.programs.cargo.enable;
-              installCargo = true;
-              installRustc = true;
-              installRustfmt = true;
-            };
-            ts_ls.enable = true;
-            zls.enable = true;
-          };
-          keymaps = {
-            lspBuf = {
-              K = "hover";
-              gd = "definition";
-              "<leader>ca" = "code_action";
-              "<leader>rr" = "rename";
-            };
+  flake.modules.homeManager.nvim = {
+    programs.nixvim = {
+      plugins.lsp = {
+        enable = true;
+        inlayHints = true;
+        # Languages with non-trivial config (kotlin_lsp, rust_analyzer) live
+        # in languages/*.nix. A language gets its own file only when it has
+        # something beyond `enable = true;`.
+        servers = {
+          astro.enable = true;
+          gopls.enable = true;
+          nixd.enable = true;
+          ts_ls.enable = true;
+          zls.enable = true;
+        };
+        keymaps = {
+          lspBuf = {
+            K = "hover";
+            gd = "definition";
+            "<leader>ca" = "code_action";
+            "<leader>rr" = "rename";
           };
         };
-        keymaps = [
-          {
-            action = "<cmd>Telescope lsp_document_symbols<CR>";
-            key = "<leader>o";
-            mode = [ "n" ];
-          }
-          {
-            action = "<cmd>Telescope lsp_dynamic_workspace_symbols<CR>";
-            key = "<leader>O";
-            mode = [ "n" ];
-          }
-          {
-            action = "<cmd>Telescope lsp_incoming_calls<CR>";
-            key = "<leader>fu";
-            mode = [ "n" ];
-          }
-          {
-            action = "<cmd>Telescope lsp_references<CR>";
-            key = "<leader>fU";
-            mode = [ "n" ];
-          }
-          {
-            action = "<cmd>Telescope lsp_implementations<CR>";
-            key = "<leader>fi";
-            mode = [ "n" ];
-          }
-        ];
       };
+      keymaps = [
+        {
+          action = "<cmd>Telescope lsp_document_symbols<CR>";
+          key = "<leader>o";
+          mode = [ "n" ];
+        }
+        {
+          action = "<cmd>Telescope lsp_dynamic_workspace_symbols<CR>";
+          key = "<leader>O";
+          mode = [ "n" ];
+        }
+        {
+          action = "<cmd>Telescope lsp_incoming_calls<CR>";
+          key = "<leader>fu";
+          mode = [ "n" ];
+        }
+        {
+          action = "<cmd>Telescope lsp_references<CR>";
+          key = "<leader>fU";
+          mode = [ "n" ];
+        }
+        {
+          action = "<cmd>Telescope lsp_implementations<CR>";
+          key = "<leader>fi";
+          mode = [ "n" ];
+        }
+      ];
     };
+  };
 }

--- a/modules/home/nvim/lsp.nix
+++ b/modules/home/nvim/lsp.nix
@@ -23,44 +23,6 @@ _: {
             ts_ls.enable = true;
             zls.enable = true;
           };
-          luaConfig.pre = ''
-            local augroup = vim.api.nvim_create_augroup('Autoformat', {})
-
-            local function format(buf)
-              local null_ls_sources = require('null-ls.sources')
-              local ft = vim.bo[buf].filetype
-
-              local has_null_ls = #null_ls_sources.get_available(ft, 'NULL_LS_FORMATTING') > 0
-
-              vim.lsp.buf.format({
-                bufnr = buf,
-                filter = function(client)
-                  if has_null_ls then
-                    return client.name == 'null-ls'
-                  else
-                    return true
-                  end
-                end,
-              })
-            end
-          '';
-          onAttach =
-            # lua
-            ''
-              if client.supports_method('textDocument/formatting') then
-                 vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
-                -- Format the current buffer on save
-                vim.api.nvim_create_autocmd('BufWritePre', {
-                  group = augroup;
-                  buffer = bufnr;
-                  callback = function()
-                    if vim.b.format_on_write ~= false then
-                      format(bufnr)
-                    end
-                  end,
-                })
-              end
-            '';
           keymaps = {
             lspBuf = {
               K = "hover";

--- a/modules/home/nvim/lsp.nix
+++ b/modules/home/nvim/lsp.nix
@@ -3,7 +3,6 @@ _: {
     { config, pkgs, ... }:
     {
       programs.nixvim = {
-        plugins.telescope.enable = true;
         plugins.lsp = {
           enable = true;
           inlayHints = true;

--- a/modules/home/nvim/nvim.nix
+++ b/modules/home/nvim/nvim.nix
@@ -26,23 +26,6 @@
         clipboard.providers.wl-copy.enable = true;
         # Add this to plugins below once switching to 24.11
         globals.mapleader = " ";
-        opts = {
-          # Set tab width to 4 spaces (instead of 8)
-          tabstop = 4;
-          # Set how many spaces will be inserted when tab is pressed
-          softtabstop = 2;
-          showtabline = 2;
-          expandtab = true;
-
-          # Enable auto indenting and set it to spaces
-          smartindent = true;
-          shiftwidth = 2;
-
-          # Enable smart indenting (see https://stackoverflow.com/questions/1204149/smart-wrap-in-vim)
-          breakindent = true;
-
-          swapfile = false;
-        };
         filetype.extension = {
           log = "log";
         };
@@ -55,23 +38,12 @@
         };
         keymaps = [
           {
-            action = "<cmd>split<CR>";
-            key = ''<leader>"'';
-            mode = [ "n" ];
-          }
-          {
-            action = "<cmd>vsplit<CR>";
-            key = "<leader>%";
-            mode = [ "n" ];
-          }
-          {
             action = "<ESC>";
             key = "jj";
             mode = [ "i" ];
           }
         ];
         plugins = {
-          nvim-surround.enable = true;
           none-ls = {
             enable = true;
             sources = {
@@ -91,7 +63,6 @@
               diagnostics.actionlint.enable = true;
             };
           };
-          sleuth.enable = true;
           treesitter = {
             enable = true;
             settings = {

--- a/modules/home/nvim/nvim.nix
+++ b/modules/home/nvim/nvim.nix
@@ -55,26 +55,6 @@
         };
         keymaps = [
           {
-            action = "<cmd>Telescope find_files<CR>";
-            key = "<leader>ff";
-            mode = [ "n" ];
-          }
-          {
-            action = "<cmd>Telescope live_grep<CR>";
-            key = "<leader>fg";
-            mode = [ "n" ];
-          }
-          {
-            action = "<cmd>Telescope buffers<CR>";
-            key = "<leader>fb";
-            mode = [ "n" ];
-          }
-          {
-            action = "<cmd>Telescope help_tags<CR>";
-            key = "<leader>fh";
-            mode = [ "n" ];
-          }
-          {
             action = "<cmd>split<CR>";
             key = ''<leader>"'';
             mode = [ "n" ];
@@ -112,38 +92,6 @@
             };
           };
           sleuth.enable = true;
-          telescope = {
-            enable = true;
-            extensions.ui-select.enable = true;
-            extensions.fzf-native.enable = true;
-            settings =
-              let
-                rgArgs = [
-                  "--hidden"
-                  "--glob"
-                  "!**/.git/*"
-                ];
-              in
-              {
-                defaults = {
-                  vimgrep_arguments = [
-                    (lib.getExe pkgs.ripgrep)
-                    "--color=never"
-                    "--no-heading"
-                    "--with-filename"
-                    "--line-number"
-                    "--column"
-                    "--smart-case"
-                  ]
-                  ++ rgArgs;
-                };
-                pickers.find_files.find_command = [
-                  (lib.getExe pkgs.ripgrep)
-                  "--files"
-                ]
-                ++ rgArgs;
-              };
-          };
           treesitter = {
             enable = true;
             settings = {

--- a/modules/home/nvim/nvim.nix
+++ b/modules/home/nvim/nvim.nix
@@ -25,16 +25,6 @@
         clipboard.providers.wl-copy.enable = true;
         # Add this to plugins below once switching to 24.11
         globals.mapleader = " ";
-        filetype.extension = {
-          log = "log";
-        };
-        files = {
-          "ftplugin/log.lua" = {
-            opts = {
-              wrap = false;
-            };
-          };
-        };
         keymaps = [
           {
             action = "<ESC>";

--- a/modules/home/nvim/nvim.nix
+++ b/modules/home/nvim/nvim.nix
@@ -3,7 +3,6 @@
     {
       config,
       lib,
-      pkgs,
       ...
     }:
     {
@@ -43,34 +42,6 @@
             mode = [ "i" ];
           }
         ];
-        plugins = {
-          none-ls = {
-            enable = true;
-            sources = {
-              formatting = {
-                gofmt.enable = true;
-                nixfmt = {
-                  enable = true;
-                  package = pkgs.nixfmt;
-                };
-                prettier = {
-                  enable = true;
-                  # should be removed once https://github.com/nix-community/nixvim/pull/4234 has been merged
-                  package = pkgs.prettier;
-                  disableTsServerFormatter = true;
-                };
-              };
-              diagnostics.actionlint.enable = true;
-            };
-          };
-          treesitter = {
-            enable = true;
-            settings = {
-              indent.enable = true;
-              highlight.enable = true;
-            };
-          };
-        };
       };
     };
 }

--- a/modules/home/nvim/snippets.nix
+++ b/modules/home/nvim/snippets.nix
@@ -1,0 +1,60 @@
+_: {
+  flake.modules.homeManager.nvim = {
+    programs.nixvim = {
+      plugins = {
+        cmp_luasnip.enable = true;
+        luasnip = {
+          enable = true;
+          fromLua = [
+            {
+              paths = ./snippets;
+            }
+          ];
+        };
+        friendly-snippets.enable = true;
+      };
+      keymaps = [
+        {
+          action.__raw =
+            # lua
+            ''
+              function()
+                local ls = require "luasnip"
+                if ls.expand_or_jumpable() then
+                  ls.expand_or_jump()
+                end
+              end
+            '';
+          key = "<C-k>";
+          mode = [
+            "i"
+            "s"
+          ];
+          options = {
+            silent = true;
+          };
+        }
+        {
+          action.__raw =
+            # lua
+            ''
+              function()
+                local ls = require "luasnip"
+                if ls.jumpable(-1) then
+                  ls.jump(-1)
+                end
+              end
+            '';
+          key = "<C-j>";
+          mode = [
+            "i"
+            "s"
+          ];
+          options = {
+            silent = true;
+          };
+        }
+      ];
+    };
+  };
+}

--- a/modules/home/nvim/syntax.nix
+++ b/modules/home/nvim/syntax.nix
@@ -1,0 +1,11 @@
+_: {
+  flake.modules.homeManager.nvim = {
+    programs.nixvim.plugins.treesitter = {
+      enable = true;
+      settings = {
+        indent.enable = true;
+        highlight.enable = true;
+      };
+    };
+  };
+}

--- a/modules/home/nvim/ui.nix
+++ b/modules/home/nvim/ui.nix
@@ -1,20 +1,6 @@
 _: {
   flake.modules.homeManager.nvim = {
     programs.nixvim = {
-      colorschemes.catppuccin = {
-        enable = true;
-        settings = {
-          flavour = "macchiato";
-          term_colors = true;
-          integrations = {
-            treesitter = true;
-            gitsigns = true;
-            native_lsp.enabled = true;
-            neotree = true;
-          };
-        };
-      };
-
       opts = {
         number = true;
         relativenumber = true;
@@ -46,25 +32,8 @@ _: {
             show_end = false;
           };
         };
-        neo-tree.enable = true;
-        oil = {
-          enable = true;
-          settings.skip_confirm_for_simple_edits = true;
-        };
         web-devicons.enable = true;
       };
-      keymaps = [
-        {
-          action = "<cmd>Neotree filesystem reveal toggle left<CR>";
-          key = "<C-n>";
-          mode = [ "n" ];
-        }
-        {
-          action = "<cmd>Oil<CR>";
-          key = "-";
-          mode = [ "n" ];
-        }
-      ];
     };
   };
 }

--- a/modules/home/nvim/ui.nix
+++ b/modules/home/nvim/ui.nix
@@ -1,39 +1,16 @@
 _: {
   flake.modules.homeManager.nvim = {
-    programs.nixvim = {
-      opts = {
-        number = true;
-        relativenumber = true;
-
-        # Enable 24-bit colors
-        termguicolors = true;
-
-        # Enable the sign column to prevent the screen from jumping
-        signcolumn = "yes";
-
-        # Highlight cursor line
-        cursorline = true;
-
-        # Remaining lines visibile before starting to scroll
-        scrolloff = 5;
-
-        list = true;
-        listchars = "tab:→·,lead:·,space:·,trail:~,extends:→,precedes:←,nbsp:␣";
-      };
-      # Show diagnostic as a virtual line but only below the current cursor line
-      diagnostic.settings.virtual_lines.current_line = true;
-      plugins = {
-        dropbar.enable = true;
-        lualine.enable = true;
-        indent-blankline = {
-          enable = true;
-          settings.scope = {
-            show_start = false;
-            show_end = false;
-          };
+    programs.nixvim.plugins = {
+      dropbar.enable = true;
+      lualine.enable = true;
+      indent-blankline = {
+        enable = true;
+        settings.scope = {
+          show_start = false;
+          show_end = false;
         };
-        web-devicons.enable = true;
       };
+      web-devicons.enable = true;
     };
   };
 }


### PR DESCRIPTION
## Summary

Refactor `modules/home/nvim/` so each file owns a single concern instead of a single plugin or a grab-bag. Pure relocation — no behavior changes, no new options.

Before, `nvim.nix` (157 lines) mixed base config with telescope, none-ls, treesitter, nvim-surround, and shell integration. Telescope was enabled in three different files. `completion.nix` mixed cmp with luasnip+snippets. `ui.nix` mixed colorscheme, visual opts, file explorers, and statusline chrome. The format-on-save autocmd lived in `lsp.nix` even though it's about formatting.

After:

- `nvim.nix` — only base nixvim enable, mapleader, fish `v` alias, MANPAGER, jj→ESC
- `editor.nix` — tab/indent + visual opts, nvim-surround, sleuth, split keymaps
- `colorscheme.nix` — catppuccin + integrations
- `ui.nix` — lualine, dropbar, indent-blankline, web-devicons
- `file-explorer.nix` — neo-tree + oil
- `finder.nix` — telescope (single home)
- `completion.nix` — cmp + sources + snippet.expand bridge
- `snippets.nix` — luasnip + friendly-snippets + cmp_luasnip + jump keymaps
- `syntax.nix` — treesitter base
- `formatting.nix` — none-ls base + format-on-save autocmd (moved off `lsp.nix`)
- `lsp.nix` — LSP enable + trivial server enables + LSP keymaps. Per-language servers with non-trivial config moved to `languages/`. Redundant `plugins.telescope.enable` dropped.
- `languages/kotlin.nix`, `languages/rust.nix`, `languages/log.nix` — languages with config beyond a plain `enable = true;`. Trivial enables (astro, gopls, nixd, ts_ls, zls) stay grouped in `lsp.nix`.

Each commit is atomic and builds cleanly against framework-13 nixos + bene HM + benedikt HM.