### PR TITLE
romm: package, module and srv-prod-5 deployment

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -29,6 +29,8 @@ jobs:
             runner: ubuntu-latest
           - configuration: directions
             runner: ubuntu-24.04-arm
+          - configuration: test-vm
+            runner: ubuntu-latest
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 result
+test-vm.qcov2
 
 # auto generated config file by git-hooks.nix
 .pre-commit-config.yaml

--- a/modules/hosts/srv-prod-5/configuration.nix
+++ b/modules/hosts/srv-prod-5/configuration.nix
@@ -6,6 +6,7 @@
       proxmox-vm
       tailscale
       navidrome-on-srv-prod-5
+      romm-on-srv-prod-5
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
     ];
 

--- a/modules/hosts/srv-prod-5/secrets.yaml
+++ b/modules/hosts/srv-prod-5/secrets.yaml
@@ -1,11 +1,12 @@
 acme:
     cloudflare-dns-api-token: ENC[AES256_GCM,data:VpHbP9bXun9ELm5h6Z2L/zDAbGDg8dP0AKoEag4erV/mtraEsoldh+67FnLFul6I48c6KuM=,iv:NtKQ2uwtjGRt+IVwOfzH7sSVwUcO5MtpckPYLxK4QrQ=,tag:jtUdC8R3exQLyndisKp3IA==,type:str]
+romm:
+    auth-secret-key: ENC[AES256_GCM,data:L5XEu0kCK6eUxaa8pJ/ijpIh0rI9XWcjM2LTkcTpbzTx6jRMBRGvQtjfyrcldYNDr4BqjwZDS+a2BdrFx/B/lw==,iv:DOg/Ddp3BjCTYE9AocJzHaEiLcY7AAA02aunD4jC6Ew=,tag:3jxjwKj+6t3NafQi77J9vQ==,type:str]
 tailscale:
     auth-key: ENC[AES256_GCM,data:4HWaZR5kTVKQ5H/LhSwLnSfpAII5dD2W9LcHNLsRSxG7VO0pOOBvBcV7I8q8CnHK6xQ4C6EIPFl+TigfdA==,iv:dO5SKCzIj5H9MJhn/+gJ+hejdXJR0kRVMCDzsW0UAQU=,tag:M4mm6INQPYkel3o04L9DBg==,type:str]
 sops:
     age:
-        - recipient: age14dnfyq56r7exkjx58gs4s8xlhn6sd05l3aufr540r374ca7mcf6qdv0yhw
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2WWpZU1IwWEkzcG5TMEZz
             VDZoWk9MWWZZbG9KLzNCYjljK1JUV25CMG1FCkQ5dERmVURYTDRyOXZXYXJ2ZzVP
@@ -13,8 +14,8 @@ sops:
             ZXV0SEtjaUlPdENjSStFRGpYYSsrRFkK7fub9QjYdBGwjizmBhD4wg34r5ZkOCcf
             25/EK+vIbbTy6X6h5C7PToYfl8F7t02x1LrfdgKxH7LobWSkRuFC3g==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1se2j989f53yz5h9fap4u67kxjru0zvmhxgaqafrsx0uqpws3895q67g86s
-          enc: |
+          recipient: age14dnfyq56r7exkjx58gs4s8xlhn6sd05l3aufr540r374ca7mcf6qdv0yhw
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2M2k3SHlnSW92eWpOaVZh
             UWJscEo5eDQ4L1plKy8vbWR4bE5qRnhCR1g4CnRNZVphQVJlTWdnbElvU2F0T3FI
@@ -22,7 +23,8 @@ sops:
             RktXVFhuZTdibTFFV1NzeHRyMWdIU2sK8bV7WkMgfwCU9EWBxlQZNf3a//SV5oab
             WiW7bNc11kTdEfAc7oEF6eDqu1GaMTJ+KlTPIJ3RyAKHnArSKVE++Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-18T19:24:02Z"
-    mac: ENC[AES256_GCM,data:2dgtsvgvqiKe3/FxMlCQpD69ZEzBKOn3Dfv9E8F1yDqyRtKG4YaHx5t3bDpXgMfibVw3S8hd1/8k7mI3cuaxYJxQxdGakBcab/zs3WWCu/UtCcitXuPb2qYvpAVX/Bu0oZvwuXHH1pgspWFc9tDhAr7+o7mVcDihLKfZJw5T4Rs=,iv:Wc4DDg1J12Fk3YOJH6C4chn7xKithI7PJf0Z4zVhm78=,tag:GhPSZyvJEou+r7EZvBJz7A==,type:str]
+          recipient: age1se2j989f53yz5h9fap4u67kxjru0zvmhxgaqafrsx0uqpws3895q67g86s
+    lastmodified: "2026-06-26T12:17:58Z"
+    mac: ENC[AES256_GCM,data:oq4qmdFNs/mlkOlVkWsSA/ezS8I9i38R/3OsBT+bAEk5pc6oNujtEFdvyrKhCURCm5F0mz7DSoQ/6dZ9mTz1b359wT2hnBJfJ1mEpoN3L9spYDQHqjmBEHcGfiK2Wi4CgIthNrA80BBhnImJgs/PS7Ke/oBFrBeUH1SdzTGSkwI=,iv:pTn63eWjEbq19gFdI5pxzw+RtjplugLYtvq66CW/5jM=,tag:fVNwbfaA7ljRFoK+WXDcLw==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.2
+    version: 3.13.1

--- a/modules/hosts/srv-prod-5/services/romm.nix
+++ b/modules/hosts/srv-prod-5/services/romm.nix
@@ -1,0 +1,52 @@
+{ config, ... }:
+let
+  inherit (config.flake.modules.nixos) romm;
+in
+{
+  flake.modules.nixos.romm-on-srv-prod-5 =
+    { config, ... }:
+    {
+      imports = [ romm ];
+
+      sops.secrets."romm/auth-secret-key" = { };
+
+      sops.templates."romm.env" = {
+        owner = "romm";
+        content = ''
+          ROMM_AUTH_SECRET_KEY=${config.sops.placeholder."romm/auth-secret-key"}
+        '';
+      };
+
+      services.romm = {
+        enable = true;
+        environmentFiles = [
+          config.sops.templates."romm.env".path
+        ];
+        # The romm module sets up the nginx virtualHost (root, /api, /ws,
+        # /netplay). https-proxy adds ACME + TLS on the same hostName via
+        # attribute-set merging.
+        nginx = {
+          enable = true;
+          hostName = "roms.srv-prod-5.ritter.family";
+        };
+      };
+
+      services.https-proxy = {
+        enable = true;
+        configurations = [
+          {
+            fqdn = "roms.srv-prod-5.ritter.family";
+            aliases = [ "roms.ritter.family" ];
+            target = null;
+          }
+        ];
+      };
+
+      fileSystems."/var/lib/romm/library" = {
+        fsType = "nfs";
+        device = "storage.ritter.family:/mnt/default-pool/romm-library";
+      };
+      systemd.services.romm-api.unitConfig.RequiresMountsFor = "/var/lib/romm/library";
+      systemd.services.romm-worker.unitConfig.RequiresMountsFor = "/var/lib/romm/library";
+    };
+}

--- a/modules/hosts/test-vm/configuration.nix
+++ b/modules/hosts/test-vm/configuration.nix
@@ -1,0 +1,57 @@
+{ config, ... }:
+{
+  flake.modules.nixos.test-vm = {
+    imports = with config.flake.modules.nixos; [
+      system-base
+      romm
+    ];
+
+    networking.hostName = "test-vm";
+    networking.firewall.allowedTCPPorts = [ 80 ];
+
+    # Placeholders so `nix flake check` can evaluate
+    # nixosConfigurations.test-vm.config.system.build.toplevel. The
+    # qemu-vm module that gets pulled in for `.config.system.build.vm`
+    # supplies the real values.
+    boot.loader.systemd-boot.enable = true;
+    fileSystems."/" = {
+      device = "/dev/disk/by-label/nixos";
+      fsType = "ext4";
+    };
+
+    users.users.root.initialPassword = "root";
+
+    environment.etc."romm-test.env".text = ''
+      ROMM_AUTH_SECRET_KEY=test-vm-secret-not-for-production
+    '';
+
+    services.romm = {
+      enable = true;
+      environmentFiles = [ "/etc/romm-test.env" ];
+      nginx = {
+        enable = true;
+        hostName = "localhost";
+      };
+    };
+
+    # VM-only knobs picked up by nixos-rebuild build-vm.
+    virtualisation.vmVariant = {
+      virtualisation = {
+        memorySize = 2048;
+        cores = 2;
+        diskSize = 8192;
+        graphics = false;
+        forwardPorts = [
+          {
+            from = "host";
+            host.port = 8080;
+            guest.port = 80;
+          }
+        ];
+      };
+      services.getty.autologinUser = "root";
+    };
+
+    system.stateVersion = "26.05";
+  };
+}

--- a/modules/hosts/test-vm/flake-parts.nix
+++ b/modules/hosts/test-vm/flake-parts.nix
@@ -1,0 +1,4 @@
+{ config, ... }:
+{
+  flake.nixosConfigurations = config.flake.lib.mkNixos "x86_64-linux" "test-vm";
+}

--- a/modules/nixos/gatus.nix
+++ b/modules/nixos/gatus.nix
@@ -65,6 +65,15 @@ _: {
                 "[STATUS] == 200"
               ];
             }
+            {
+              name = "ROMM";
+              url = "https://roms.ritter.family/api/heartbeat";
+              interval = "5m";
+              conditions = [
+                "[STATUS] == 200"
+                "[BODY].VERSION != null"
+              ];
+            }
           ];
         };
       };

--- a/modules/nixos/homepage.nix
+++ b/modules/nixos/homepage.nix
@@ -77,6 +77,13 @@ _: {
                 icon = "navidrome.svg";
               };
             }
+            {
+              "ROMM" = {
+                description = "Self-hosted ROM manager and player";
+                href = "https://roms.ritter.family/";
+                icon = "romm.svg";
+              };
+            }
           ];
         }
         {

--- a/modules/nixos/romm.nix
+++ b/modules/nixos/romm.nix
@@ -142,9 +142,38 @@ _: {
         environmentFiles = lib.mkOption {
           type = lib.types.listOf lib.types.path;
           default = [ ];
+          example = [ "/run/secrets/romm.env" ];
           description = ''
-            systemd EnvironmentFile= entries. Use this for secrets such as
-            ROMM_AUTH_SECRET_KEY, DB_PASSWD, and metadata-source API keys.
+            systemd EnvironmentFile= entries.
+
+            ROMM refuses to start unless `ROMM_AUTH_SECRET_KEY` is set.
+            It is the instance secret used to sign session cookies, CSRF
+            tokens, and JWTs, and must be stable across restarts (rotating
+            it silently logs every user out). It is unrelated to the
+            admin user's password; the admin account is created via the
+            setup wizard on first boot.
+
+            Generate a 32-byte hex value with:
+
+            ```
+            nix run nixpkgs#openssl -- rand -hex 32
+            ```
+
+            and ship it to the unit via sops-nix, agenix, or any file
+            outside the Nix store. The file's contents should look like:
+
+            ```
+            ROMM_AUTH_SECRET_KEY=2f1c4b6e8d3a5f7e9c2b4d6f8a0c1e3d5f7a9b2c4d6e8f0a1b3c5d7e9f1a3b5c
+            ```
+
+            Optional but common entries in the same file:
+
+            - `DB_PASSWD` — required when `database.createLocally = false`
+              (skipped when the local MariaDB path uses unix_socket auth).
+            - Metadata-source API keys: `IGDB_CLIENT_ID`,
+              `IGDB_CLIENT_SECRET`, `MOBYGAMES_API_KEY`,
+              `SCREENSCRAPER_USER`, `SCREENSCRAPER_PASSWORD`,
+              `STEAMGRIDDB_API_KEY`, `RETROACHIEVEMENTS_API_KEY`.
           '';
         };
 
@@ -237,7 +266,7 @@ _: {
       config = lib.mkIf cfg.enable {
         users.users.${cfg.user} = lib.mkIf (cfg.user == "romm") {
           isSystemUser = true;
-          group = cfg.group;
+          inherit (cfg) group;
           home = cfg.stateDir;
         };
         users.groups.${cfg.group} = lib.mkIf (cfg.group == "romm") { };

--- a/modules/nixos/romm.nix
+++ b/modules/nixos/romm.nix
@@ -1,0 +1,390 @@
+_: {
+  flake.modules.nixos.romm =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.services.romm;
+      pkg = cfg.package;
+
+      redisServerName = "romm";
+
+      useSocketAuth = cfg.database.createLocally && cfg.database.driver != "postgresql";
+
+      defaultSettings = lib.filterAttrs (_: v: v != null) (
+        {
+          ROMM_BASE_PATH = cfg.stateDir;
+          ROMM_PORT = toString cfg.port;
+          ROMM_DB_DRIVER = cfg.database.driver;
+          DB_HOST = cfg.database.host;
+          DB_PORT = toString cfg.database.port;
+          DB_NAME = cfg.database.name;
+          DB_USER = cfg.database.user;
+          REDIS_HOST = cfg.redis.host;
+          REDIS_PORT = toString cfg.redis.port;
+        }
+        // lib.optionalAttrs useSocketAuth {
+          # ensureUsers creates 'romm'@'localhost' with the unix_socket auth
+          # plugin, so the OS user authenticates without a password. ROMM
+          # still requires a non-empty DB_PASSWD to construct the URL, but
+          # mariadb-connector ignores it when unix_socket is in the query.
+          DB_PASSWD = "unused";
+          DB_QUERY_JSON = ''{"unix_socket": "/run/mysqld/mysqld.sock"}'';
+        }
+      );
+
+      serviceDefaults = {
+        environment = lib.mapAttrs (_: v: if lib.isBool v then lib.boolToString v else toString v) (
+          defaultSettings // cfg.settings
+        );
+        serviceConfig = {
+          User = cfg.user;
+          Group = cfg.group;
+          WorkingDirectory = cfg.stateDir;
+          EnvironmentFile = cfg.environmentFiles;
+          # Hardening (mirrors stirling-pdf upstream module).
+          AmbientCapabilities = "";
+          CapabilityBoundingSet = "";
+          LockPersonality = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "strict";
+          ReadWritePaths = [ cfg.stateDir ];
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @clock @setuid @chown"
+          ];
+          # 0027 (group readable) so a co-located nginx serving the
+          # library via X-Accel-Redirect can read files; 0077 otherwise.
+          UMask = if cfg.nginx.enable then "0027" else "0077";
+        };
+      };
+    in
+    {
+      options.services.romm = {
+        enable = lib.mkEnableOption "the ROMM ROM manager";
+
+        package = lib.mkPackageOption pkgs "romm" { };
+
+        user = lib.mkOption {
+          type = lib.types.str;
+          default = "romm";
+          description = "User to run ROMM under.";
+        };
+
+        group = lib.mkOption {
+          type = lib.types.str;
+          default = "romm";
+          description = "Group to run ROMM under.";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 5000;
+          description = "TCP port the gunicorn backend listens on (loopback).";
+        };
+
+        workers = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 1;
+          description = "Number of gunicorn worker processes.";
+        };
+
+        stateDir = lib.mkOption {
+          type = lib.types.path;
+          default = "/var/lib/romm";
+          description = ''
+            ROMM_BASE_PATH. Holds library/, resources/, assets/, config/,
+            launchbox/ and sync/ subdirectories.
+          '';
+        };
+
+        settings = lib.mkOption {
+          type = lib.types.attrsOf (
+            lib.types.oneOf [
+              lib.types.str
+              lib.types.int
+              lib.types.bool
+            ]
+          );
+          default = { };
+          example = {
+            ENABLE_SCHEDULED_RESCAN = true;
+            LOGLEVEL = "INFO";
+          };
+          description = ''
+            Freeform ROMM_* environment variables. Overrides defaults derived
+            from the typed `database`, `redis`, `port`, and `stateDir` options.
+            See env.template in upstream for the complete list.
+          '';
+        };
+
+        environmentFiles = lib.mkOption {
+          type = lib.types.listOf lib.types.path;
+          default = [ ];
+          description = ''
+            systemd EnvironmentFile= entries. Use this for secrets such as
+            ROMM_AUTH_SECRET_KEY, DB_PASSWD, and metadata-source API keys.
+          '';
+        };
+
+        database = {
+          createLocally = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Whether to enable a local MariaDB instance and create the
+              database and user. When false, configure connection details
+              via the other `database.*` options and supply DB_PASSWD in
+              `environmentFiles`.
+            '';
+          };
+          driver = lib.mkOption {
+            type = lib.types.enum [
+              "mariadb"
+              "mysql"
+              "postgresql"
+            ];
+            default = "mariadb";
+            description = "ROMM_DB_DRIVER value.";
+          };
+          host = lib.mkOption {
+            type = lib.types.str;
+            default = "localhost";
+            description = "DB_HOST.";
+          };
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 3306;
+            description = "DB_PORT.";
+          };
+          name = lib.mkOption {
+            type = lib.types.str;
+            default = "romm";
+            description = "DB_NAME.";
+          };
+          user = lib.mkOption {
+            type = lib.types.str;
+            default = "romm";
+            description = "DB_USER.";
+          };
+        };
+
+        redis = {
+          createLocally = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Whether to enable a dedicated local Redis (Valkey) server.
+              When false, set `redis.host`/`redis.port` and supply
+              REDIS_PASSWORD via `environmentFiles`.
+            '';
+          };
+          host = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1";
+            description = "REDIS_HOST.";
+          };
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 6479;
+            description = "REDIS_PORT.";
+          };
+        };
+
+        nginx = {
+          enable = lib.mkEnableOption "an nginx virtualHost serving the frontend and proxying API traffic";
+          hostName = lib.mkOption {
+            type = lib.types.str;
+            example = "roms.example.com";
+            description = "FQDN for the nginx virtualHost.";
+          };
+        };
+
+        enableScheduler = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Run rqscheduler. Required if any ENABLE_SCHEDULED_* setting is true.";
+        };
+
+        enableWatcher = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Run watchfiles against the library to trigger rescans on filesystem changes.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        users.users.${cfg.user} = lib.mkIf (cfg.user == "romm") {
+          isSystemUser = true;
+          group = cfg.group;
+          home = cfg.stateDir;
+        };
+        users.groups.${cfg.group} = lib.mkIf (cfg.group == "romm") { };
+
+        # nginx must read library files when serving them via X-Accel-Redirect.
+        users.users.nginx.extraGroups = lib.mkIf cfg.nginx.enable [ cfg.group ];
+
+        systemd.tmpfiles.rules = [
+          "d ${cfg.stateDir} 0750 ${cfg.user} ${cfg.group} -"
+          "d ${cfg.stateDir}/library 0750 ${cfg.user} ${cfg.group} -"
+          "d ${cfg.stateDir}/resources 0750 ${cfg.user} ${cfg.group} -"
+          "d ${cfg.stateDir}/assets 0750 ${cfg.user} ${cfg.group} -"
+          "d ${cfg.stateDir}/config 0750 ${cfg.user} ${cfg.group} -"
+          "d ${cfg.stateDir}/launchbox 0750 ${cfg.user} ${cfg.group} -"
+          "d ${cfg.stateDir}/sync 0750 ${cfg.user} ${cfg.group} -"
+        ];
+
+        services.mysql = lib.mkIf (cfg.database.createLocally && cfg.database.driver != "postgresql") {
+          enable = true;
+          package = lib.mkDefault pkgs.mariadb;
+          ensureDatabases = [ cfg.database.name ];
+          ensureUsers = [
+            {
+              name = cfg.database.user;
+              ensurePermissions."${cfg.database.name}.*" = "ALL PRIVILEGES";
+            }
+          ];
+        };
+
+        services.postgresql = lib.mkIf (cfg.database.createLocally && cfg.database.driver == "postgresql") {
+          enable = true;
+          ensureDatabases = [ cfg.database.name ];
+          ensureUsers = [
+            {
+              name = cfg.database.user;
+              ensureDBOwnership = true;
+            }
+          ];
+        };
+
+        services.redis.servers.${redisServerName} = lib.mkIf cfg.redis.createLocally {
+          enable = true;
+          port = cfg.redis.port;
+          bind = cfg.redis.host;
+        };
+
+        systemd.services.romm-migrate = lib.recursiveUpdate serviceDefaults {
+          description = "ROMM: run alembic migrations and seed caches";
+          after = [
+            "network.target"
+          ]
+          ++ lib.optional (cfg.database.createLocally && cfg.database.driver != "postgresql") "mysql.service"
+          ++ lib.optional (
+            cfg.database.createLocally && cfg.database.driver == "postgresql"
+          ) "postgresql.service"
+          ++ lib.optional cfg.redis.createLocally "redis-${redisServerName}.service";
+          requires =
+            lib.optional (cfg.database.createLocally && cfg.database.driver != "postgresql") "mysql.service"
+            ++ lib.optional (
+              cfg.database.createLocally && cfg.database.driver == "postgresql"
+            ) "postgresql.service"
+            ++ lib.optional cfg.redis.createLocally "redis-${redisServerName}.service";
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = [
+              "${pkg}/bin/romm-migrate"
+              "${pkg}/bin/romm-startup"
+            ];
+          };
+        };
+
+        systemd.services.romm-api = lib.recursiveUpdate serviceDefaults {
+          description = "ROMM: gunicorn API server";
+          after = [ "romm-migrate.service" ];
+          requires = [ "romm-migrate.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig.ExecStart = "${pkg}/bin/romm-api --bind 127.0.0.1:${toString cfg.port} --workers ${toString cfg.workers}";
+        };
+
+        systemd.services.romm-worker = lib.recursiveUpdate serviceDefaults {
+          description = "ROMM: rq background worker";
+          after = [ "romm-migrate.service" ];
+          requires = [ "romm-migrate.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig.ExecStart = "${pkg}/bin/romm-worker high default low";
+        };
+
+        systemd.services.romm-scheduler = lib.mkIf cfg.enableScheduler (
+          lib.recursiveUpdate serviceDefaults {
+            description = "ROMM: rqscheduler";
+            after = [ "romm-migrate.service" ];
+            requires = [ "romm-migrate.service" ];
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig.ExecStart = "${pkg}/bin/romm-scheduler";
+          }
+        );
+
+        systemd.services.romm-watcher = lib.mkIf cfg.enableWatcher (
+          lib.recursiveUpdate serviceDefaults {
+            description = "ROMM: filesystem watcher";
+            after = [ "romm-api.service" ];
+            wantedBy = [ "multi-user.target" ];
+            serviceConfig.ExecStart = ''
+              ${pkg.passthru.pythonEnv}/bin/watchfiles \
+                "python3 watcher.py ${cfg.stateDir}/library" ${cfg.stateDir}/library
+            '';
+          }
+        );
+
+        services.nginx = lib.mkIf cfg.nginx.enable {
+          enable = true;
+          virtualHosts.${cfg.nginx.hostName} = {
+            locations = {
+              "/" = {
+                root = "${pkg}/share/romm/frontend";
+                tryFiles = "$uri $uri/ /index.html";
+              };
+              "/assets/romm/resources/".alias = "${cfg.stateDir}/resources/";
+              # X-Accel-Redirect target for ROMM's ROM/firmware download
+              # endpoints. Not directly reachable from outside.
+              "/library/" = {
+                alias = "${cfg.stateDir}/library/";
+                extraConfig = "internal;";
+              };
+              "/api" = {
+                proxyPass = "http://127.0.0.1:${toString cfg.port}";
+                recommendedProxySettings = true;
+              };
+              "/ws" = {
+                proxyPass = "http://127.0.0.1:${toString cfg.port}";
+                proxyWebsockets = true;
+                recommendedProxySettings = true;
+                extraConfig = "proxy_read_timeout 86400;";
+              };
+              "/netplay" = {
+                proxyPass = "http://127.0.0.1:${toString cfg.port}";
+                proxyWebsockets = true;
+                recommendedProxySettings = true;
+              };
+            };
+            extraConfig = ''
+              client_max_body_size 0;
+            '';
+          };
+        };
+      };
+    };
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -6,4 +6,5 @@ rec {
   jfmt-java = callPackage ./jfmt-java { inherit maven_4; };
   kotlin-lsp = callPackage ./kotlin-lsp { };
   maven_4 = callPackage ./maven_4 { };
+  romm = callPackage ./romm { };
 }

--- a/packages/romm/default.nix
+++ b/packages/romm/default.nix
@@ -1,0 +1,240 @@
+{
+  lib,
+  callPackage,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchurl,
+  makeWrapper,
+  python313,
+  p7zip,
+  file, # provides libmagic for python-magic
+}:
+let
+  version = "4.9.2";
+
+  src = fetchFromGitHub {
+    owner = "rommapp";
+    repo = "romm";
+    tag = version;
+    hash = "sha256-mXb7mJF4QVWZIqrTQaKmGYe4ewppbRhyQC0UcIloEDY=";
+  };
+
+  frontend = callPackage ./frontend.nix { inherit src version; };
+
+  emulatorjs =
+    let
+      ejsVersion = "4.2.3";
+    in
+    stdenvNoCC.mkDerivation {
+      pname = "emulatorjs";
+      version = ejsVersion;
+      src = fetchurl {
+        url = "https://github.com/EmulatorJS/EmulatorJS/releases/download/v${ejsVersion}/${ejsVersion}.7z";
+        hash = "sha256-B9RRvAb6OtBKsw2blOtjrDStC6vuUtYDV7ACvejzhQs=";
+      };
+      nativeBuildInputs = [ p7zip ];
+      dontUnpack = true;
+      installPhase = ''
+        mkdir -p $out
+        7z x -y "$src" -o"$out"
+      '';
+    };
+
+  python = python313.override {
+    self = python;
+    packageOverrides = pyfinal: _pyprev: {
+      # ROMM pins rq-scheduler to a git fork that adds username/SSL support.
+      # Track upstream pyproject.toml for the exact rev/branch.
+      # nixpkgs's python313Packages.crontab is actually doctormo's
+      # python-crontab; rq-scheduler depends on Josiah Carlson's separate
+      # `crontab` package on PyPI, so we provide it ourselves.
+      jc-crontab = pyfinal.buildPythonPackage rec {
+        pname = "crontab";
+        version = "1.0.4";
+        pyproject = true;
+        src = pyfinal.fetchPypi {
+          inherit pname version;
+          hash = "sha256-cVsOXhBbxiyWg8u5PBzFgh4Ho+KNF0BFdtItunqJbJI=";
+        };
+        build-system = [ pyfinal.setuptools ];
+        doCheck = false;
+        pythonImportsCheck = [ "crontab" ];
+      };
+
+      rq-scheduler = pyfinal.buildPythonPackage {
+        pname = "rq-scheduler";
+        version = "unstable-2025-09-23";
+        pyproject = true;
+        src = fetchFromGitHub {
+          owner = "adamantike";
+          repo = "rq-scheduler";
+          rev = "feat/script-options-username-ssl";
+          hash = "sha256-VOgMuzSDwCIWOlWc2+dxZHXqO3IigTi0F7ZRAzbgzLE=";
+        };
+        build-system = [ pyfinal.setuptools ];
+        dependencies = [
+          pyfinal.rq
+          pyfinal.jc-crontab
+          pyfinal.python-dateutil
+        ];
+        doCheck = false;
+      };
+
+      strsimpy = pyfinal.buildPythonPackage rec {
+        pname = "strsimpy";
+        version = "0.2.1";
+        pyproject = true;
+        src = pyfinal.fetchPypi {
+          inherit pname version;
+          hash = "sha256-CELrV/evhsiCpZobyHIewlgKJn5WP9BQPO0pcgQDcsk=";
+        };
+        build-system = [ pyfinal.setuptools ];
+        doCheck = false;
+      };
+
+      zipfile-inflate64 = pyfinal.buildPythonPackage rec {
+        pname = "zipfile-inflate64";
+        version = "0.1";
+        format = "wheel";
+        src = pyfinal.fetchPypi {
+          pname = "zipfile_inflate64";
+          inherit version format;
+          python = "py3";
+          dist = "py3";
+          hash = "sha256-tETzrqkEBh1wLtvtWPlS5UShnc8g8u2EvYic9Ea4e30=";
+        };
+        dependencies = [ pyfinal.inflate64 ];
+        doCheck = false;
+      };
+    };
+  };
+
+  pythonEnv = python.withPackages (
+    ps: with ps; [
+      aiohttp
+      alembic
+      anyio
+      asyncssh
+      authlib
+      bcrypt
+      colorama
+      defusedxml
+      fastapi
+      fastapi-pagination
+      gunicorn
+      httpx
+      itsdangerous
+      joserfc
+      mariadb
+      mysql-connector
+      mutagen
+      opentelemetry-api
+      opentelemetry-distro
+      opentelemetry-exporter-otlp
+      opentelemetry-instrumentation-aiohttp-client
+      opentelemetry-instrumentation-fastapi
+      opentelemetry-instrumentation-httpx
+      opentelemetry-instrumentation-redis
+      opentelemetry-instrumentation-sqlalchemy
+      passlib
+      pillow
+      psycopg
+      pydantic
+      pydash
+      python-dotenv
+      python-magic
+      python-multipart
+      python-socketio
+      pyyaml
+      redis
+      rq
+      rq-scheduler
+      sentry-sdk
+      sqlalchemy
+      starlette
+      streaming-form-data
+      strsimpy
+      ua-parser
+      unidecode
+      uvicorn
+      uvicorn-worker
+      watchfiles
+      yarl
+      zipfile-inflate64
+    ]
+  );
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "romm";
+  inherit version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/romm $out/bin
+    cp -r backend $out/share/romm/backend
+    cp -r ${frontend} $out/share/romm/frontend
+    chmod -R u+w $out/share/romm/frontend
+    # Upstream's Dockerfile copies frontend/assets/ (source-level static
+    # files: platform logos, dashboard icons, scraper logos, ...) on top
+    # of the built dist. The SPA references them by unhashed path.
+    cp -r frontend/assets/. $out/share/romm/frontend/assets/
+    chmod -R u+w $out/share/romm/frontend/assets
+    # frontend/assets/emulatorjs only holds three placeholder SVGs;
+    # replace it with the actual EmulatorJS bundle.
+    rm -rf $out/share/romm/frontend/assets/emulatorjs
+    ln -s ${emulatorjs} $out/share/romm/frontend/assets/emulatorjs
+
+    # Entry points: cd into backend so relative paths (alembic.ini, migrations,
+    # config templates) resolve as they do in the official Docker image.
+    makeWrapper ${pythonEnv}/bin/gunicorn $out/bin/romm-api \
+      --chdir $out/share/romm/backend \
+      --prefix PYTHONPATH : $out/share/romm/backend \
+      --prefix PATH : ${lib.makeBinPath [ p7zip ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ file ]} \
+      --add-flags "--worker-class uvicorn_worker.UvicornWorker main:app"
+
+    makeWrapper ${pythonEnv}/bin/rq $out/bin/romm-worker \
+      --chdir $out/share/romm/backend \
+      --prefix PYTHONPATH : $out/share/romm/backend \
+      --prefix PATH : ${lib.makeBinPath [ p7zip ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ file ]} \
+      --add-flags "worker --path $out/share/romm/backend"
+
+    makeWrapper ${pythonEnv}/bin/rqscheduler $out/bin/romm-scheduler \
+      --chdir $out/share/romm/backend \
+      --prefix PYTHONPATH : $out/share/romm/backend \
+      --add-flags "--path $out/share/romm/backend"
+
+    makeWrapper ${pythonEnv}/bin/alembic $out/bin/romm-migrate \
+      --chdir $out/share/romm/backend \
+      --prefix PYTHONPATH : $out/share/romm/backend \
+      --add-flags "upgrade head"
+
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/romm-startup \
+      --chdir $out/share/romm/backend \
+      --prefix PYTHONPATH : $out/share/romm/backend \
+      --add-flags "startup.py"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit frontend pythonEnv;
+    tests.romm-vm-test = callPackage ./nixos-test.nix {
+      romm = finalAttrs.finalPackage;
+    };
+  };
+
+  meta = with lib; {
+    description = "ROMM — a self-hosted ROM manager and player";
+    homepage = "https://github.com/rommapp/romm";
+    license = licenses.agpl3Only;
+    platforms = platforms.linux;
+    mainProgram = "romm-api";
+  };
+})

--- a/packages/romm/frontend.nix
+++ b/packages/romm/frontend.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildNpmPackage,
+  nodejs_24,
+  src,
+  version,
+}:
+buildNpmPackage {
+  pname = "romm-frontend";
+  inherit version src;
+
+  sourceRoot = "${src.name}/frontend";
+
+  npmDepsHash = "sha256-jKZ9zuWaQz2oOioMoN4IQc/jhfyHQQ/v4NzHrOQZLvM=";
+
+  makeCacheWritable = true;
+
+  nodejs = nodejs_24;
+
+  # `npm run build` chains `prebuild` (tsx scripts/build-tokens.ts) and `vite build`.
+  # Output lands in ./dist.
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r dist/. $out/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Vue/Vite frontend for ROMM";
+    homepage = "https://github.com/rommapp/romm";
+    license = licenses.agpl3Only;
+    platforms = platforms.all;
+  };
+}

--- a/packages/romm/nixos-test.nix
+++ b/packages/romm/nixos-test.nix
@@ -1,0 +1,99 @@
+{ pkgs, romm }:
+let
+  rommModule = (import ../../modules/nixos/romm.nix { }).flake.modules.nixos.romm;
+
+  # Stub upstream that always responds with an X-Accel-Redirect header,
+  # used to assert nginx's internal /library/ location actually serves
+  # files (without depending on ROMM auth/DB state).
+  xaccelStub = pkgs.writers.writePython3 "xaccel-stub" { flakeIgnore = [ "E305" ]; } ''
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+    class H(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("X-Accel-Redirect", "/library/test-rom.gb")
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+    HTTPServer(("127.0.0.1", 9999), H).serve_forever()
+  '';
+in
+pkgs.testers.runNixOSTest {
+  name = "romm-vm-test";
+
+  nodes.machine = {
+    imports = [ rommModule ];
+
+    virtualisation = {
+      memorySize = 2048;
+      cores = 2;
+      diskSize = 8192;
+    };
+
+    services.romm = {
+      enable = true;
+      package = romm;
+      environmentFiles = [ "/etc/romm-test.env" ];
+      nginx = {
+        enable = true;
+        hostName = "localhost";
+      };
+    };
+
+    environment.etc."romm-test.env".text = ''
+      ROMM_AUTH_SECRET_KEY=this-is-not-a-real-secret-key-just-for-tests
+    '';
+
+    systemd.services.xaccel-stub = {
+      description = "X-Accel-Redirect test stub";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig.ExecStart = xaccelStub;
+    };
+
+    services.nginx.virtualHosts.localhost.locations."/test-xaccel" = {
+      proxyPass = "http://127.0.0.1:9999";
+      recommendedProxySettings = true;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("mysql.service")
+    machine.wait_for_unit("redis-romm.service")
+    machine.wait_for_unit("romm-migrate.service")
+    machine.wait_for_unit("romm-api.service")
+    machine.wait_for_unit("romm-worker.service")
+    machine.wait_for_unit("xaccel-stub.service")
+    machine.wait_for_open_port(80)
+    machine.wait_for_open_port(5000)
+    machine.wait_for_open_port(9999)
+
+    with subtest("frontend is served"):
+        machine.succeed("curl -fsS http://localhost/ -o /tmp/index.html")
+        machine.succeed("grep -q '<html' /tmp/index.html")
+
+    with subtest("api heartbeat responds"):
+        machine.wait_until_succeeds("curl -fsS http://localhost/api/heartbeat -o /tmp/heartbeat.json")
+        machine.succeed("grep -q VERSION /tmp/heartbeat.json")
+
+    with subtest("X-Accel-Redirect /library/ serves ROM files"):
+        # Drop a file with the same ownership/mode ROMM creates: romm:romm 0640.
+        machine.succeed(
+            "install -d -o romm -g romm -m 0750 /var/lib/romm/library && "
+            "install -o romm -g romm -m 0640 /dev/stdin "
+            "/var/lib/romm/library/test-rom.gb <<<'NIX-TEST-ROM'"
+        )
+        # Direct external access must be 404 — the location is `internal`.
+        code = machine.succeed(
+            "curl -sS -o /dev/null -w '%{http_code}' "
+            "http://localhost/library/test-rom.gb"
+        ).strip()
+        assert code == "404", f"expected 404 from internal /library/, got {code}"
+
+        # Triggered via X-Accel-Redirect, the file body comes through.
+        body = machine.succeed("curl -fsS http://localhost/test-xaccel").strip()
+        assert body == "NIX-TEST-ROM", f"expected 'NIX-TEST-ROM', got {body!r}"
+  '';
+}


### PR DESCRIPTION
## Summary
- Add a `romm` package: `buildNpmPackage` frontend + a `python313` environment (with `rq-scheduler` from upstream's git fork, plus `strsimpy`, `zipfile-inflate64` and Carlson's `crontab` inline since they are absent from nixpkgs) + console wrappers for the multi-process backend.
- Add a `services.romm` NixOS module modelling the upstream layout as separate systemd units (migrate oneshot, api, worker, optional scheduler/watcher), with opt-in MariaDB/Redis/nginx integrations in the paperless/immich style so the module stays upstream-friendly.
- Expose a VM test via `romm.passthru.tests.romm-vm-test` (not pulled in by `nix flake check`) that asserts `romm-migrate` runs `alembic upgrade head` cleanly and that both the static frontend and the unauthenticated `/api/heartbeat` are served through the nginx vhost.
- Wire ROMM onto `srv-prod-5` with NFS-backed library storage, sops-templated `ROMM_AUTH_SECRET_KEY` and `DB_PASSWD`, and `services.https-proxy` adding ACME + TLS on the same hostName as the romm-managed nginx vhost.