### PR TITLE
directions: expose minio on homepage and gatus

### DIFF
--- a/modules/nixos/gatus.nix
+++ b/modules/nixos/gatus.nix
@@ -57,6 +57,14 @@ _: {
                 "[STATUS] == 200"
               ];
             }
+            {
+              name = "Minio";
+              url = "https://minio.srv-prod-3.ritter.family/minio/health/live";
+              interval = "5m";
+              conditions = [
+                "[STATUS] == 200"
+              ];
+            }
           ];
         };
       };

--- a/modules/nixos/homepage.nix
+++ b/modules/nixos/homepage.nix
@@ -120,6 +120,13 @@ _: {
                 icon = "fritzbox.svg";
               };
             }
+            {
+              "Minio" = {
+                description = "S3-compatible object storage";
+                href = "https://minio.srv-prod-3.ritter.family/console/";
+                icon = "minio.svg";
+              };
+            }
           ];
         }
         {


### PR DESCRIPTION
## Summary
- Add Minio (running on srv-prod-3) to the Infrastructure section of the homepage dashboard
- Add a `/minio/health/live` endpoint to gatus monitoring