### PR TITLE
beszel: deploy hub on srv-prod-1, agents on directions and VM hosts

### DIFF
--- a/modules/generic/system-constants.nix
+++ b/modules/generic/system-constants.nix
@@ -11,6 +11,7 @@ _: {
         '';
       };
       config.systemConstants = {
+        adminEmail = "beneritter@gmail.com";
         adminKeys = {
           framework-13 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGsQc3GN4b8scuDR7PghdB+Eu4zUgSwgrgqplpNDR3Lq";
           starlite = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII2+ifShP1n5ZV8Q/VKXvpdKAJycgQ0kgkiz7YOPmKec";

--- a/modules/hosts/directions/configuration.nix
+++ b/modules/hosts/directions/configuration.nix
@@ -4,6 +4,7 @@
     imports = with config.flake.modules.nixos; [
       system-server
       adguard
+      beszel-agent
       gatus
       homepage
       tailscale

--- a/modules/hosts/directions/services/https-proxy.nix
+++ b/modules/hosts/directions/services/https-proxy.nix
@@ -6,6 +6,11 @@ _: {
         enable = true;
         configurations = [
           {
+            fqdn = "beszel.ritter.family";
+            target = "https://beszel.srv-prod-1.ritter.family";
+            proxyWebsockets = true;
+          }
+          {
             fqdn = "books.ritter.family";
             target = "https://books.srv-prod-2.ritter.family";
             extraConfig = ''

--- a/modules/hosts/srv-prod-1/configuration.nix
+++ b/modules/hosts/srv-prod-1/configuration.nix
@@ -5,6 +5,8 @@
       system-server
       proxmox-vm
       tailscale
+      beszel-hub
+      beszel-agent
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
     ];
 

--- a/modules/hosts/srv-prod-1/secrets.yaml
+++ b/modules/hosts/srv-prod-1/secrets.yaml
@@ -1,5 +1,9 @@
 acme:
     cloudflare-dns-api-token: ENC[AES256_GCM,data:a5DHml4KgMSYVDJqp+zuvIetNVPEapplM/0gQPcKwt2ZmWaHNqLHq3zXTg9AXHefrX9fexU=,iv:bAs+8DRN3rM+15QioQp0M+q4UtUNwIJMsDYZbToy8SM=,tag:kFadh9Z/QeKgKiyZbbiV6A==,type:str]
+beszel:
+    hub-public-key: ENC[AES256_GCM,data:iYcwKB6hbUjxMPXvtZ5FzeIhtPAm8Em4akHcBnFwJwc5ST70RDnX46z1/GO2NwNnWTQWZCzsjG2C7TXCSYNlfGHQdr9Z7thSjWICBZgHXF+1BslAGBuk4Uk1JTzTQciuyDg=,iv:+Lu2XgHogTRt2YlmZno35FAGUTM8UK63JsnrA1w8zw8=,tag:ZvJHVsAm5zEXDEy1Fzwffw==,type:str]
+    hub-private-key: ENC[AES256_GCM,data:PB9EfHwqHEgArUGK4cifGP3d8ewWcci9aAlJad6SMvSkyI/XTWf+pLBQk9A5FRLfWOmADi/jXCQUI836Aem1+mYBdOZjBKXjoznsx1lyqdApa/zoig8E/xgUy4yQ246N1V2M/nrfUxCs0TPJCgyly1pSK0rtl2XT5Wl7Tc4qbXpwlMcAWb3+vbttJGu7SXekEMxUEFtV7cf4DOJha5FM/Dwlr3yBbnAwazfinDf9bH6ox8eYtB78ecby2Mk6KIPGEMoDV7py5OeGAzVoX+x3u3auZLsi+REBuKU5QPBv3V1pqjeGfTihaVYFJNEXNLY4pNsanLi5764aG771sRvwiZK+YdM7WKZ8uXuSvjZ0PrAn27jkr7ofqWhGyK8eJcW44++80crnkU9igetWdCQTSPP34XQ4BAaJVE8fMSZ0CWNd7if5DP717LeDBmaBGwwDk7P5U4K7L7vQERHxo8E9KMZrBNakD2HLzyJJqWdyUdxqR6JuMcwauuBUONiJ3br1z9gccU9uK2+BXPFy3zG68JoCGpw8dwf33I5E,iv:L6Qd4FQme+00L5ju8CtevI2Qv48Q8rbLmPicFkmji2M=,tag:SEOEQxkYbXir8Ivru/LU7w==,type:str]
+    hub-admin-password: ENC[AES256_GCM,data:llY2vzZ9NArDvxfsj/647bRVLGQP5u6AZwt5boHYVxQmYZHzXDPhxR6U,iv:l8ciz/K8FkKV9q0neN5tMiBk8IEsG2II9a7eyAS4mI8=,tag:Jcbd36KSqd2BcBeh3OMw8w==,type:str]
 tailscale:
     auth-key: ENC[AES256_GCM,data:yJPso/RhmVB7PYEICQeIqYHcGSFkXvv/wLk9u0N6cQAF2vqpG8f8KZmv24OzpDn17D0AfGMTjrYjPExT8WE=,iv:68tS5iFuoYPH3Ac/EJChDyaLnSczGPpp1l6FGAhohsU=,tag:bzwIuVZESClSQ0eRr76HUw==,type:str]
 sops:
@@ -22,7 +26,7 @@ sops:
             WDkv0PuxDk1YIRfNEwnkgpsmFc1IUHtQYGiISFxmXscDpzxDgPTfEQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1ch7v7lwn3sq0u60a80z4y69fcdw49l64sedw8gh72afc0wcujqmscftpdn
-    lastmodified: "2026-06-25T09:43:03Z"
-    mac: ENC[AES256_GCM,data:pAgHIBpitc+kkTDhepNKjG2rOisul6Q3jq1kj9PLYigjjO43tM13/mfonYW7bcRxUUjwOLOzdm90C1Gvomy70picmmDhFCjPEmiWejMY0z1jTSvmJ3/FxiZAPOikSvogEKySElWHEWD7MUtb/UkeH4VjxUDCfI4Tl/Qa6zF7sdY=,iv:3iwO+1vsT9V4TmTf8AUzH0nZEHLHJhQOyhAew5OItdI=,tag:G8sHpAQ7gpYVfpXEOiLU1A==,type:str]
+    lastmodified: "2026-06-26T16:49:14Z"
+    mac: ENC[AES256_GCM,data:6VBLbxRR06yM68slj+zsMwo+Qz/cmL22rhFY2tCxt8ZD//T806R1MUhFz4X9RKt8ZFq5JvswLB6C5bBHEsG6fCeYsFiQ+vAXTqX8mKSm9YYdtsXI/bIhk3TRVmvkl0BQ53FYGOUgYa2NcrBxHk9HZ7Pt6ltJ4e+9vSDcTs6N+OE=,iv:Fhcklf4ens0DWgRDIdfcjdhi6cBO6kpawH7ePvIsIPU=,tag:1HASK1MdRLv1ciuwcCZFPw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/modules/hosts/srv-prod-2/configuration.nix
+++ b/modules/hosts/srv-prod-2/configuration.nix
@@ -6,6 +6,7 @@
       proxmox-vm
       stirling-pdf
       tailscale
+      beszel-agent
       calibre-web-on-srv-prod-2
       git-server-on-srv-prod-2
       nextcloud-on-srv-prod-2

--- a/modules/hosts/srv-prod-3/configuration.nix
+++ b/modules/hosts/srv-prod-3/configuration.nix
@@ -5,6 +5,7 @@
       system-server
       proxmox-vm
       tailscale
+      beszel-agent
       minio
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
     ];

--- a/modules/hosts/srv-prod-4/configuration.nix
+++ b/modules/hosts/srv-prod-4/configuration.nix
@@ -5,6 +5,7 @@
       system-server
       proxmox-vm
       tailscale
+      beszel-agent
       immich-on-srv-prod-4
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
     ];

--- a/modules/hosts/srv-prod-5/configuration.nix
+++ b/modules/hosts/srv-prod-5/configuration.nix
@@ -5,6 +5,7 @@
       system-server
       proxmox-vm
       tailscale
+      beszel-agent
       navidrome-on-srv-prod-5
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
     ];

--- a/modules/nixos/beszel-agent.nix
+++ b/modules/nixos/beszel-agent.nix
@@ -1,0 +1,14 @@
+_: {
+  flake.modules.nixos.beszel-agent = _: {
+    services.beszel.agent = {
+      enable = true;
+      openFirewall = true;
+      environment = {
+        PORT = "45876";
+        # Bezel Hub's SSH public key, which is stored in /var/lib/beszel-hub/id_ed25519.pub.
+        # For Beszel on srv-prod-1, the value is stored in modules/hosts/srv-prod-1/secrets.yaml
+        KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDM4/5m4XKP1a+BT7nVqmo4NaHJIk26rS+NbemzQw6y5 bene@framework-13";
+      };
+    };
+  };
+}

--- a/modules/nixos/beszel-hub.nix
+++ b/modules/nixos/beszel-hub.nix
@@ -1,0 +1,60 @@
+_: {
+  flake.modules.nixos.beszel-hub =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    let
+      fqdn = "beszel.${config.networking.hostName}.ritter.family";
+      yamlFormat = pkgs.formats.yaml { };
+      monitoredHosts = [
+        "directions"
+        "srv-prod-1"
+        "srv-prod-2"
+        "srv-prod-3"
+        "srv-prod-4"
+        "srv-prod-5"
+      ];
+      configYml = yamlFormat.generate "beszel-config.yml" {
+        systems = map (h: {
+          name = h;
+          host = "${h}.ritter.family";
+          port = 45876;
+          users = [ config.systemConstants.adminEmail ];
+        }) monitoredHosts;
+      };
+    in
+    {
+      sops.secrets."beszel/hub-private-key" = { };
+      sops.secrets."beszel/hub-admin-password" = { };
+      sops.templates."beszel-hub-env".content = ''
+        USER_PASSWORD=${config.sops.placeholder."beszel/hub-admin-password"}
+      '';
+
+      services.beszel.hub = {
+        enable = true;
+        environment.USER_EMAIL = config.systemConstants.adminEmail;
+        environmentFile = config.sops.templates."beszel-hub-env".path;
+      };
+
+      systemd.services.beszel-hub.serviceConfig.LoadCredential = [
+        "id_ed25519:${config.sops.secrets."beszel/hub-private-key".path}"
+      ];
+      systemd.services.beszel-hub.preStart = ''
+        install -m 600 "$CREDENTIALS_DIRECTORY/id_ed25519" "$STATE_DIRECTORY/id_ed25519"
+        install -m 644 ${configYml} "$STATE_DIRECTORY/config.yml"
+      '';
+
+      services.https-proxy = {
+        enable = true;
+        configurations = [
+          {
+            inherit fqdn;
+            target = "http://localhost:${toString config.services.beszel.hub.port}";
+            proxyWebsockets = true;
+          }
+        ];
+      };
+    };
+}

--- a/modules/nixos/gatus.nix
+++ b/modules/nixos/gatus.nix
@@ -65,6 +65,14 @@ _: {
                 "[STATUS] == 200"
               ];
             }
+            {
+              name = "Beszel";
+              url = "https://beszel.ritter.family/api/health";
+              interval = "5m";
+              conditions = [
+                "[STATUS] == 200"
+              ];
+            }
           ];
         };
       };

--- a/modules/nixos/homepage.nix
+++ b/modules/nixos/homepage.nix
@@ -132,10 +132,10 @@ _: {
         {
           "Monitoring" = [
             {
-              "Grafana" = {
-                description = "Grafana Dashboards";
-                href = "https://grafana.ritter.family/";
-                icon = "grafana.svg";
+              "Beszel" = {
+                description = "Lightweight server monitoring";
+                href = "https://beszel.ritter.family/";
+                icon = "beszel.svg";
               };
             }
             {

--- a/modules/nixos/https-proxy.nix
+++ b/modules/nixos/https-proxy.nix
@@ -68,7 +68,7 @@ _: {
         security.acme = {
           acceptTerms = true;
           defaults = {
-            email = "beneritter@gmail.com";
+            email = config.systemConstants.adminEmail;
             dnsProvider = "cloudflare";
             dnsPropagationCheck = true;
             credentialFiles = {


### PR DESCRIPTION
## Summary

- Stand up Beszel hub on srv-prod-1, proxied at `beszel.ritter.family` via directions
- Pre-seed the hub SSH keypair via sops + systemd `LoadCredential` so the dashboard comes up in one deploy
- Declare monitored systems in a generated `config.yml` — six hosts auto-registered on hub start
- Run beszel-agent on directions and srv-prod-{1..5}, sharing the hub pubkey as a plain Nix string
- Add the Beszel card to the homepage dashboard and a `/api/health` endpoint to gatus
- Drop the unused Grafana entry from the homepage dashboard

## Deploy notes

1. `ssh-keygen -t ed25519 -N '' -f beszel-hub`
2. `sops modules/hosts/srv-prod-1/secrets.yaml` → add `beszel/hub-private-key` with the private key contents
3. Replace `ssh-ed25519 AAAAREPLACEME` in `modules/nixos/beszel-agent.nix` with the contents of `beszel-hub.pub`
4. Deploy srv-prod-1, create the `beneritter@gmail.com` admin user via the web UI, `systemctl restart beszel-hub` so config.yml resolves users, then deploy the rest