### PR TITLE
framework-13: decompose configuration.nix into modules

### DIFF
--- a/modules/hosts/directions/configuration.nix
+++ b/modules/hosts/directions/configuration.nix
@@ -7,7 +7,7 @@
       beszel-agent
       gatus
       homepage
-      tailscale
+      tailscale-server
       https-proxy-on-directions
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
     ];

--- a/modules/hosts/framework-13/configuration.nix
+++ b/modules/hosts/framework-13/configuration.nix
@@ -1,43 +1,16 @@
 { config, ... }:
 {
-  flake.modules.nixos.framework-13 =
-    {
-      pkgs,
-      ...
-    }:
-    {
-      imports = with config.flake.modules.nixos; [
-        system-desktop
-        bene-on-framework-13
-        gaming
-      ];
+  flake.modules.nixos.framework-13 = {
+    imports = with config.flake.modules.nixos; [
+      system-desktop
+      bene-on-framework-13
+      gaming
+      printing
+      podman
+      tailscale
+      fhs-support
+    ];
 
-      boot.kernelPackages = pkgs.linuxPackages_latest;
-
-      services.fwupd.enable = true;
-
-      services.printing.enable = true;
-      services.avahi = {
-        enable = true;
-        # Enables mDNS NSS plugin for IPv4. Enabling it allows applications to resolve names in the .local domain
-        # This is required for printing on a HP network printer
-        nssmdns4 = true;
-      };
-
-      services.tailscale = {
-        enable = true;
-        extraSetFlags = [ "--accept-dns=false" ];
-      };
-
-      virtualisation.podman = {
-        enable = true;
-        dockerCompat = true;
-      };
-      environment.systemPackages = [
-        pkgs.podman-compose
-      ];
-      programs.nix-ld.enable = true;
-
-      system.stateVersion = "25.05";
-    };
+    system.stateVersion = "25.05";
+  };
 }

--- a/modules/hosts/framework-13/hardware/hardware.nix
+++ b/modules/hosts/framework-13/hardware/hardware.nix
@@ -1,10 +1,16 @@
 { inputs, ... }:
 {
-  flake.modules.nixos.framework-13 = {
-    imports = [ inputs.nixos-hardware.nixosModules.framework-amd-ai-300-series ];
+  flake.modules.nixos.framework-13 =
+    { pkgs, ... }:
+    {
+      imports = [ inputs.nixos-hardware.nixosModules.framework-amd-ai-300-series ];
 
-    hardware.facter.reportPath = ./facter.json;
-    # see https://github.com/numtide/nixos-facter-modules/issues/62
-    hardware.facter.detected.dhcp.enable = false;
-  };
+      hardware.facter.reportPath = ./facter.json;
+      # see https://github.com/numtide/nixos-facter-modules/issues/62
+      hardware.facter.detected.dhcp.enable = false;
+
+      boot.kernelPackages = pkgs.linuxPackages_latest;
+
+      services.fwupd.enable = true;
+    };
 }

--- a/modules/hosts/srv-offsite-1/configuration.nix
+++ b/modules/hosts/srv-offsite-1/configuration.nix
@@ -3,7 +3,7 @@
   flake.modules.nixos.srv-offsite-1 = {
     imports = with config.flake.modules.nixos; [
       system-server
-      tailscale
+      tailscale-server
       minio
       minio-sync-on-srv-offsite-1
       weekly-update-window-on-srv-offsite-1

--- a/modules/hosts/srv-prod-1/configuration.nix
+++ b/modules/hosts/srv-prod-1/configuration.nix
@@ -4,7 +4,7 @@
     imports = with config.flake.modules.nixos; [
       system-server
       proxmox-vm
-      tailscale
+      tailscale-server
       beszel-hub
       beszel-agent
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })

--- a/modules/hosts/srv-prod-2/configuration.nix
+++ b/modules/hosts/srv-prod-2/configuration.nix
@@ -5,7 +5,7 @@
       system-server
       proxmox-vm
       stirling-pdf
-      tailscale
+      tailscale-server
       beszel-agent
       calibre-web-on-srv-prod-2
       git-server-on-srv-prod-2

--- a/modules/hosts/srv-prod-3/configuration.nix
+++ b/modules/hosts/srv-prod-3/configuration.nix
@@ -4,7 +4,7 @@
     imports = with config.flake.modules.nixos; [
       system-server
       proxmox-vm
-      tailscale
+      tailscale-server
       beszel-agent
       minio
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })

--- a/modules/hosts/srv-prod-4/configuration.nix
+++ b/modules/hosts/srv-prod-4/configuration.nix
@@ -4,7 +4,7 @@
     imports = with config.flake.modules.nixos; [
       system-server
       proxmox-vm
-      tailscale
+      tailscale-server
       beszel-agent
       immich-on-srv-prod-4
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })

--- a/modules/hosts/srv-prod-5/configuration.nix
+++ b/modules/hosts/srv-prod-5/configuration.nix
@@ -4,7 +4,7 @@
     imports = with config.flake.modules.nixos; [
       system-server
       proxmox-vm
-      tailscale
+      tailscale-server
       beszel-agent
       navidrome-on-srv-prod-5
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })

--- a/modules/hosts/srv-prod-6/configuration.nix
+++ b/modules/hosts/srv-prod-6/configuration.nix
@@ -4,7 +4,7 @@
     imports = with config.flake.modules.nixos; [
       system-server
       proxmox-vm
-      tailscale
+      tailscale-server
       beszel-agent
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
       (config.flake.factory.github-runners { count = 4; })

--- a/modules/nixos/fhs-support.nix
+++ b/modules/nixos/fhs-support.nix
@@ -1,0 +1,6 @@
+_: {
+  # nix-ld provides an FHS-style loader so unpatched dynamic binaries can run.
+  flake.modules.nixos.fhs-support = {
+    programs.nix-ld.enable = true;
+  };
+}

--- a/modules/nixos/podman.nix
+++ b/modules/nixos/podman.nix
@@ -1,0 +1,13 @@
+_: {
+  flake.modules.nixos.podman =
+    { pkgs, ... }:
+    {
+      virtualisation.podman = {
+        enable = true;
+        dockerCompat = true;
+      };
+      environment.systemPackages = [
+        pkgs.podman-compose
+      ];
+    };
+}

--- a/modules/nixos/printing.nix
+++ b/modules/nixos/printing.nix
@@ -1,0 +1,11 @@
+_: {
+  flake.modules.nixos.printing = {
+    services.printing.enable = true;
+    services.avahi = {
+      enable = true;
+      # Enables mDNS NSS plugin for IPv4. Enabling it allows applications to resolve names in the .local domain
+      # This is required for printing on a HP network printer
+      nssmdns4 = true;
+    };
+  };
+}

--- a/modules/nixos/tailscale-server.nix
+++ b/modules/nixos/tailscale-server.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+let
+  inherit (config.flake.modules.nixos) tailscale;
+in
+{
+  flake.modules.nixos.tailscale-server =
+    { config, ... }:
+    {
+      imports = [ tailscale ];
+
+      sops.secrets."tailscale/auth-key" = { };
+      services.tailscale.authKeyFile = config.sops.secrets."tailscale/auth-key".path;
+    };
+}

--- a/modules/nixos/tailscale.nix
+++ b/modules/nixos/tailscale.nix
@@ -1,13 +1,8 @@
 _: {
-  flake.modules.nixos.tailscale =
-    { config, ... }:
-    {
-      sops.secrets."tailscale/auth-key" = { };
-
-      services.tailscale = {
-        enable = true;
-        authKeyFile = config.sops.secrets."tailscale/auth-key".path;
-        extraSetFlags = [ "--accept-dns=false" ];
-      };
+  flake.modules.nixos.tailscale = {
+    services.tailscale = {
+      enable = true;
+      extraSetFlags = [ "--accept-dns=false" ];
     };
+  };
 }


### PR DESCRIPTION
`framework-13/configuration.nix` was a grab-bag of inlined service config. Reduce it to imports + `system.stateVersion`, moving each concern to its proper home following the repo convention (machine-inherent config contributes directly to the host; reusable/toggleable concerns are named modules imported by name).

- **Machine-inherent** → `framework-13/hardware/hardware.nix`: `linuxPackages_latest` kernel + `services.fwupd`.
- **New named modules** (`modules/nixos/`): `printing` (printing + avahi mDNS for the HP printer), `podman`, `fhs-support` (nix-ld).
- **Tailscale split**: base `tailscale` module is now the interactive client (no sops); new `tailscale-server` imports it and layers the sops auth-key on top. All headless servers repointed to `tailscale-server`; the laptop keeps the keyless `tailscale`.