### PR TITLE
srv-prod-6: deploy forgejo git forge

### DIFF
--- a/modules/hosts/directions/services/https-proxy.nix
+++ b/modules/hosts/directions/services/https-proxy.nix
@@ -27,6 +27,13 @@ _: {
             target = "https://${config.home-lab.devices.fritz-box.ip}";
           }
           {
+            fqdn = "git.ritter.family";
+            target = "https://git.srv-prod-6.ritter.family";
+            extraConfig = ''
+              client_max_body_size 512M;
+            '';
+          }
+          {
             fqdn = "grafana.ritter.family";
             target = "https://grafana.srv-prod-1.ritter.family";
           }

--- a/modules/hosts/srv-prod-6/configuration.nix
+++ b/modules/hosts/srv-prod-6/configuration.nix
@@ -6,6 +6,7 @@
       proxmox-vm
       tailscale
       beszel-agent
+      forgejo-on-srv-prod-6
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
       (config.flake.factory.github-runners { count = 4; })
     ];

--- a/modules/hosts/srv-prod-6/secrets.yaml
+++ b/modules/hosts/srv-prod-6/secrets.yaml
@@ -7,6 +7,11 @@ github-runners:
     pat: ENC[AES256_GCM,data:oej1ulxZO+MeCwdPkSFf/0IHrbMBLzZa12yoHDI8Afb3SgZ1VBiyKbbF4tOKRc0g9Wb/fB7qSCcj4BM8pJcQ7B+P9Zw3xiZ7vm9obCYVTwi9y02+upQsnMElaQLg,iv:rOAMY+/9iOS6v4Pim8SY3yN5P8o4dxj39YfRsUw4qyE=,tag:0UrnsIwjHrqKt5DOPeswEA==,type:str]
     aws-access-key-id: ENC[AES256_GCM,data:q5/LXZUcKb/4NlQfHpWDdznG4qE=,iv:ULi4XIKhjyBkpKaKu9I61Zc1Rwn4Ud+oXFTNSdWaw+w=,tag:dkFKvQWObGVSu/Ug/tNv6Q==,type:str]
     aws-secret-access-key: ENC[AES256_GCM,data:X49389fVLGMbXXg6jPQS/kR8fZ4d3drFtmlP8qSsf/f2DtPyVyK3tQ==,iv:F9lHfRwMTG0ZXprcsy4cG1cRAJ+OG8wzTZAnE2vN96w=,tag:1xIi3+SoJsvgcpHhZnksQQ==,type:str]
+restic:
+    forgejo:
+        repository-password: ENC[AES256_GCM,data:vYTCywRUACiMpsIkuEVlZzXmwVm/SDtKJwTgVzNxn6iQii8fQfBE3d5kSMXZhaei90Ne0w==,iv:S2MumlbFyNrGvOT/plxFRI7ld09FFeTOFR+Su2HY1PQ=,tag:WiZf50tInry6TWwT1JPDyg==,type:str]
+        minio-access-key-id: ENC[AES256_GCM,data:S8Kppq8RDLruTUMAh/KAAhkjlhw=,iv:EoL4S5I6tZmx+NTw+zj04y2d9GiOM5W6ju5yeyg2WSU=,tag:MiP8JZT2+ruvqmA0ayvxeg==,type:str]
+        minio-secret-access-key: ENC[AES256_GCM,data:skC3M/JqJsff+7viL92cXxhogULkzmt+sxc6Ii7iJxsMHSJgKuDwOA==,iv:GQFlg0TN1RfD9wzpUUkrcxS8YIyCineWa812hLZVwGM=,tag:LBVMVFPZFZifUtgN7E+92w==,type:str]
 tailscale:
     auth-key: ENC[AES256_GCM,data:VZc5GYuJJQE/3Lt9jbAkHBYKwPagQN+asthpxEp4ZJ/rZelDXEMLl1w5Yt6CqsULiprkp+jGyb7ZUd11nA==,iv:DBhhPwKsaDdmNu030Pq8DwZHJThb7SnVtoxC+2S/o3c=,tag:JChRZJP5IKh3sTCCEgQdzg==,type:str]
 sops:
@@ -29,7 +34,7 @@ sops:
             vfg8hKZnUUyiErG+jW4j0Kl//bAyvPQB1zmHlodvTLBBWwbTUVrLeg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13yp8g09vzyeznpu0k563u6p7qdh0snh564vx3ef6x2g659nr3g7swewhuh
-    lastmodified: "2026-07-06T12:51:51Z"
-    mac: ENC[AES256_GCM,data:+eevIeH9i2g1DL/884CriMIDqAIKNwNqmEO5luielXNy3qng/0Fnf6xkx+TvzzqcrWswA8CMghTq7qwe5R80F5ZyG0qVZb1gffIEYAHxgrc5Em9JNcc4VOoba4pb8ory8YnvA507/0G1fIAM1p90pLC6Jt5915VOYeOMiZkTkeg=,iv:axWB7JfXEjn+DlBY+LoKZb1F+N6wQjEYbEiH0Zl2dg4=,tag:uOzeAkEQnoE9sBDzF+xkcw==,type:str]
+    lastmodified: "2026-07-07T09:56:06Z"
+    mac: ENC[AES256_GCM,data:gVDmfvNc9Xv45bfIqh02UuL5nrOve4A/RXnjQahutAM1qSwAmOrP8CF3FIQkvAcGhl8usCYXCA6xdASMkExPpFAv0508I/RP7L4X/opYo7MXxPb1/gQEpEcO7awMT2rZ7Ad2BCFAzmtKoFrFsdodUDC7Ct6v9kLXcY+B/uzAnsk=,iv:nqEKzhYVWUw86psl5PTGcMAm2KVa7Ns3+TxT8zB5zd0=,tag:Mu5CbKoFAjHxEs7wq+zqlw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/modules/hosts/srv-prod-6/services/forgejo.nix
+++ b/modules/hosts/srv-prod-6/services/forgejo.nix
@@ -1,0 +1,31 @@
+{ config, ... }:
+let
+  inherit (config.flake.modules.nixos) forgejo;
+  restic = import ../../srv-prod-2/services/_restic-constants.nix;
+in
+{
+  flake.modules.nixos.forgejo-on-srv-prod-6 =
+    { config, ... }:
+    {
+      imports = [ forgejo ];
+
+      sops.secrets."restic/forgejo/repository-password" = { };
+      sops.secrets."restic/forgejo/minio-access-key-id" = { };
+      sops.secrets."restic/forgejo/minio-secret-access-key" = { };
+      sops.templates."restic/forgejo/secrets.env" = {
+        content = ''
+          AWS_ACCESS_KEY_ID=${config.sops.placeholder."restic/forgejo/minio-access-key-id"}
+          AWS_SECRET_ACCESS_KEY=${config.sops.placeholder."restic/forgejo/minio-secret-access-key"}
+          RESTIC_PASSWORD=${config.sops.placeholder."restic/forgejo/repository-password"}
+        '';
+      };
+
+      services.restic.backups.forgejo = {
+        environmentFile = config.sops.templates."restic/forgejo/secrets.env".path;
+        paths = [ "/var/lib/forgejo" ];
+        repository = "${restic.bucket}/forgejo";
+        initialize = true;
+        inherit (restic) pruneOpts timerConfig;
+      };
+    };
+}

--- a/modules/nixos/forgejo.nix
+++ b/modules/nixos/forgejo.nix
@@ -1,0 +1,34 @@
+_: {
+  flake.modules.nixos.forgejo =
+    { config, ... }:
+    {
+      services.forgejo = {
+        enable = true;
+        database.type = "sqlite3";
+        settings = {
+          server = {
+            DOMAIN = "git.ritter.family";
+            ROOT_URL = "https://git.ritter.family/";
+            HTTP_ADDR = "127.0.0.1";
+            HTTP_PORT = 3000;
+            DISABLE_SSH = true;
+          };
+          service.DISABLE_REGISTRATION = true;
+        };
+      };
+
+      services.https-proxy = {
+        enable = true;
+        configurations = [
+          {
+            fqdn = "git.${config.networking.hostName}.ritter.family";
+            aliases = [ "git.ritter.family" ];
+            target = "http://localhost:3000";
+            extraConfig = ''
+              client_max_body_size 512M;
+            '';
+          }
+        ];
+      };
+    };
+}

--- a/modules/nixos/gatus.nix
+++ b/modules/nixos/gatus.nix
@@ -81,6 +81,15 @@ _: {
                 "[STATUS] == 200"
               ];
             }
+            {
+              name = "Forgejo";
+              url = "https://git.ritter.family/api/healthz";
+              interval = "5m";
+              conditions = [
+                "[STATUS] == 200"
+                "[BODY].status == pass"
+              ];
+            }
           ];
         };
       };

--- a/modules/nixos/homepage.nix
+++ b/modules/nixos/homepage.nix
@@ -80,6 +80,17 @@ _: {
           ];
         }
         {
+          "Development" = [
+            {
+              "Forgejo" = {
+                description = "Git hosting and collaboration";
+                href = "https://git.ritter.family/";
+                icon = "forgejo.svg";
+              };
+            }
+          ];
+        }
+        {
           "Smart Home" = [
             {
               "Home Assistant" = {


### PR DESCRIPTION
## Summary

Deploys a self-hosted [Forgejo](https://forgejo.org/) git forge on srv-prod-6, reachable at `git.ritter.family`.

- **`modules/nixos/forgejo.nix`** — generic module: `services.forgejo` on SQLite, bound to `127.0.0.1:3000`, built-in SSH disabled (HTTPS-only), open registration disabled. Adds an `https-proxy` vhost for `git.srv-prod-6.ritter.family` + alias `git.ritter.family`.
- **`modules/hosts/srv-prod-6/services/forgejo.nix`** — host wrapper adding a restic-to-MinIO backup of `/var/lib/forgejo`.
- **`modules/hosts/srv-prod-6/configuration.nix`** — registers `forgejo-on-srv-prod-6`.
- **`modules/hosts/directions/services/https-proxy.nix`** — public `git.ritter.family` → `https://git.srv-prod-6.ritter.family`.
- **`modules/nixos/homepage.nix`** — new "Development" group with a Forgejo tile.
- **`modules/nixos/gatus.nix`** — Forgejo `/api/healthz` uptime endpoint.

## Follow-ups

- After deploy, create the admin user via `forgejo admin user create` (no open signup).