### PR TITLE
framework-13: add forgejo-client git credential helper

### DIFF
--- a/modules/home/programs/forgejo-client.nix
+++ b/modules/home/programs/forgejo-client.nix
@@ -1,0 +1,17 @@
+_: {
+  flake.modules.nixos.forgejo-client = {
+    # git-credential-libsecret persists the Forgejo HTTPS token in the
+    # gnome-keyring Secret Service (gated by polkit) across reboots
+    services.gnome.gnome-keyring.enable = true;
+    security.polkit.enable = true;
+  };
+
+  flake.modules.homeManager.forgejo-client =
+    { pkgs, ... }:
+    {
+      # HTTPS auth for the self-hosted Forgejo (git.ritter.family). Scoped by
+      # URL so it never touches the SSH-based GitHub/chainguard remotes.
+      programs.git.settings.credential."https://git.ritter.family".helper =
+        "${pkgs.gitFull}/bin/git-credential-libsecret";
+    };
+}

--- a/modules/hosts/framework-13/bene-on-framework-13.nix
+++ b/modules/hosts/framework-13/bene-on-framework-13.nix
@@ -6,6 +6,7 @@
       imports = with config.flake.modules.nixos; [
         bene
         bitwarden
+        forgejo-client
         nextcloud-client
         sway
       ];
@@ -16,6 +17,7 @@
           bitwarden
           calibre
           desktop-essentials
+          forgejo-client
           ghostty
           intellij
           librewolf


### PR DESCRIPTION
## Summary

Adds a `forgejo-client` module so git push/fetch over HTTPS to the self-hosted Forgejo (`git.ritter.family`) can persist its access token instead of prompting every time.

- **`modules/home/programs/forgejo-client.nix`** (new, dual-context, mirrors `nextcloud-client`):
  - `flake.modules.nixos.forgejo-client` — enables `gnome-keyring` + `polkit` (the Secret Service backend the helper needs)
  - `flake.modules.homeManager.forgejo-client` — sets `credential."https://git.ritter.family".helper = git-credential-libsecret`, scoped by URL
- **`modules/hosts/framework-13/bene-on-framework-13.nix`** — imports `forgejo-client` in both the NixOS and home-manager lists.

The module owns its keyring dependency, so it's self-contained (no hidden coupling to `nextcloud-client`) and nothing lands in the shared `git.nix` — which matters because `git` is also imported in the home-manager-only work profile, where NixOS-side keyring config wouldn't apply. Scoped to framework-13 only.

Pairs with the server-side deployment in #249.