### PR TITLE
github-runners: use disk-backed workDir to fix /run exhaustion

### DIFF
--- a/modules/nixos/github-runners.nix
+++ b/modules/nixos/github-runners.nix
@@ -6,6 +6,9 @@ _: {
       lib,
       ...
     }:
+    let
+      workDirFor = num: "/var/lib/github-runners/nixos-runner-${toString num}";
+    in
     {
       # github-runners are created with dynamic users.
       # setup a supplementary group to grant read access to
@@ -39,11 +42,25 @@ _: {
       # Allow members of the github-runners group to use the nix daemon
       nix.settings.trusted-users = [ "@github-runners" ];
 
+      # The runners use a disk-backed workDir (see below). The module binds this
+      # path into the service namespace but does not create it, so it must exist
+      # beforehand. Runners run as DynamicUser (runtime UID) but are members of
+      # the github-runners group, so group-owned + 0770 lets them write & clean.
+      systemd.tmpfiles.rules = map (num: "d ${workDirFor num} 0770 root github-runners - -") (
+        lib.range 1 count
+      );
+
       services.github-runners = builtins.listToAttrs (
         map (num: {
           name = "nixos-runner-${toString num}";
           value = {
             enable = true;
+            # Default workDir is the systemd RuntimeDirectory under /run (tmpfs),
+            # which is RAM-backed and small — builds fill it up. Use disk instead.
+            workDir = workDirFor num;
+            # Changing workDir triggers a new registration; without replace the
+            # re-registration under the same name fails.
+            replace = true;
             url = "https://github.com/britter/home-lab";
             tokenType = "access";
             tokenFile = config.sops.secrets."github-runners/pat".path;


### PR DESCRIPTION
## Summary

srv-prod-6's four GitHub runners were failing builds with "no space left on device" — the default `workDir` is the systemd `RuntimeDirectory` under `/run`, which is a small RAM-backed tmpfs (hit 96%).

- Point `workDir` at `/var/lib/github-runners/nixos-runner-<n>` (extracted into a `workDirFor` helper).
- Set `replace = true`: changing `workDir` triggers a new runner registration, which fails under the same name without it.
- Add a `systemd.tmpfiles.rules` entry per runner: the module binds `workDir` into the service namespace but doesn't create it. Runners are `DynamicUser` but members of the `github-runners` group, so the dir is `root:github-runners` mode `0770` to allow write and cleanup.

`/nix/store` growth (the real long-term disk concern) is already bounded by the existing weekly `nix.gc` in `system-base`.