### PR TITLE
github-runners: host workDir in a CacheDirectory

### DIFF
--- a/modules/nixos/github-runners.nix
+++ b/modules/nixos/github-runners.nix
@@ -7,7 +7,9 @@ _: {
       ...
     }:
     let
-      workDirFor = num: "/var/lib/github-runners/nixos-runner-${toString num}";
+      # Relative form for systemd CacheDirectory= (base /var/cache).
+      cacheSubdir = num: "github-runners/nixos-runner-${toString num}";
+      workDirFor = num: "/var/cache/${cacheSubdir num}";
     in
     {
       # github-runners are created with dynamic users.
@@ -42,21 +44,16 @@ _: {
       # Allow members of the github-runners group to use the nix daemon
       nix.settings.trusted-users = [ "@github-runners" ];
 
-      # The runners use a disk-backed workDir (see below). The module binds this
-      # path into the service namespace but does not create it, so it must exist
-      # beforehand. Runners run as DynamicUser (runtime UID) but are members of
-      # the github-runners group, so group-owned + 0770 lets them write & clean.
-      systemd.tmpfiles.rules = map (num: "d ${workDirFor num} 0770 root github-runners - -") (
-        lib.range 1 count
-      );
-
       services.github-runners = builtins.listToAttrs (
         map (num: {
           name = "nixos-runner-${toString num}";
           value = {
             enable = true;
             # Default workDir is the systemd RuntimeDirectory under /run (tmpfs),
-            # which is RAM-backed and small — builds fill it up. Use disk instead.
+            # which is RAM-backed and small — builds fill it up. Use a disk-backed
+            # CacheDirectory instead (see serviceOverrides), which systemd creates
+            # and chowns to the runner's dynamic user on every start. It's a
+            # reconstructable checkout (wiped each start), so cache, not state.
             workDir = workDirFor num;
             # Changing workDir triggers a new registration; without replace the
             # re-registration under the same name fails.
@@ -69,6 +66,11 @@ _: {
               "x86_64"
             ];
             serviceOverrides = {
+              # CacheDirectory for the workDir above. systemd creates it on disk
+              # under /var/cache and chowns it to the dynamic user each start, so
+              # $HOME (= workDir) is owned by the runner and stays writable under
+              # ProtectSystem=strict.
+              CacheDirectory = [ (cacheSubdir num) ];
               SupplementaryGroups = [ "github-runners" ];
               EnvironmentFile = [ config.sops.templates.state-backend-secrets.path ];
               Environment = [


### PR DESCRIPTION
## Summary

Follow-up to #253. That change moved the runners' `workDir` off the tmpfs `/run` (which was hitting "no space left on device") to a tmpfiles-created dir under `/var/lib`, owned `root:github-runners`. That broke at runtime: the module sets `HOME=workDir`, and tools require `HOME` to be *owned* by the user — group-write isn't enough. They fell back to `HOME=/`, then failed writing `/.cache/nix` on the read-only fs (`ProtectSystem=strict`).

Use a systemd `CacheDirectory` instead:
- systemd creates it under `/var/cache`, chowns it to the runner's **dynamic user** each start (a root-owned tmpfiles dir can't do this), and exempts it from `ProtectSystem=strict` — so `HOME` is owned by the runner and writable.
- The `workDir` is a reconstructable checkout the module wipes on every start, so cache is the correct home for it — and keeps the build tree out of `/var/lib` backups.
- Drops the tmpfiles rule entirely.