### PR TITLE
github-runners: drop stray BindPaths so CacheDirectory chowns workDir

### DIFF
--- a/modules/nixos/github-runners.nix
+++ b/modules/nixos/github-runners.nix
@@ -67,10 +67,17 @@ _: {
             ];
             serviceOverrides = {
               # CacheDirectory for the workDir above. systemd creates it on disk
-              # under /var/cache and chowns it to the dynamic user each start, so
-              # $HOME (= workDir) is owned by the runner and stays writable under
-              # ProtectSystem=strict.
+              # under /var/cache and, under DynamicUser, chowns it to the runner's
+              # dynamic user each start, so $HOME (= workDir) is owned by the runner
+              # and stays writable under ProtectSystem=strict.
               CacheDirectory = [ (cacheSubdir num) ];
+              # A managed *Directory already implies its own BindPaths=; the module
+              # adds a second BindPaths=[workDir] for custom workDirs, which collides
+              # with that and shadows the chowned dir with a root-owned mount (ln in
+              # setup-work-dirs then fails with EACCES). systemd docs also say not to
+              # combine BindPaths= with DynamicUser=. Clear it so CacheDirectory owns
+              # the dir outright, mirroring the default RuntimeDirectory code path.
+              BindPaths = lib.mkForce [ ];
               SupplementaryGroups = [ "github-runners" ];
               EnvironmentFile = [ config.sops.templates.state-backend-secrets.path ];
               Environment = [


### PR DESCRIPTION
## Summary

Follow-up to #254. That change put the workDir in a `CacheDirectory`, but the runners crashed on start:

```
setup-work-dirs.sh: ln: failed to create symbolic link
'/var/cache/github-runners/nixos-runner-1/_diag': Permission denied
```

The dir was root-owned inside the service namespace.

**Cause:** a managed `*Directory=` already *implies* its own `BindPaths=`, and systemd chowns it to the dynamic user. But for a custom `workDir` the module adds a *second* `BindPaths=[workDir]` (it doesn't for the default `RuntimeDirectory`), which collides with that and shadows the chowned dir with a root-owned bind mount. systemd's docs also explicitly advise against combining `BindPaths=` with `DynamicUser=`.

**Fix:** force-clear `BindPaths` in `serviceOverrides` so `CacheDirectory` manages the dir outright — the same code path as the default `RuntimeDirectory` workDir, which works. The `CacheDirectory` is writable under `ProtectSystem=strict` without the extra bind mount.

⚠️ **One-time host cleanup:** systemd leaves already-existing dirs untouched, so the stale root-owned dirs from the previous deploy must be removed once on srv-prod-6:

```
rm -rf /var/cache/private/github-runners/*
```

Ref: `RuntimeDirectory=` / `DynamicUser=` in [systemd.exec(5)](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=).