### PR TITLE
github-runners: run as a static user to fix actions/checkout auth

### DIFF
--- a/modules/nixos/github-runners.nix
+++ b/modules/nixos/github-runners.nix
@@ -12,51 +12,49 @@ _: {
       workDirFor = num: "/var/cache/${cacheSubdir num}";
     in
     {
-      # github-runners are created with dynamic users.
-      # setup a supplementary group to grant read access to
-      # the PAT for generating a registration token.
-      users.groups.github-runners = { };
-      sops.secrets."github-runners/pat" = {
-        group = "github-runners";
-        mode = "0440";
+      # The runners share a static system user (see `user`/`group` below). A
+      # static user is required because a disk-backed workDir under DynamicUser
+      # lands in /var/{lib,cache}/private with a symlink, and actions/checkout v6
+      # writes git credentials via `includeIf.gitdir:<workDir>`; git resolves that
+      # symlink, the condition never matches, and checkout fails with "could not
+      # read Username". See https://github.com/actions/checkout/issues/2393.
+      users.users.github-runner = {
+        isSystemUser = true;
+        group = "github-runner";
       };
-      sops.secrets."github-runners/age-key" = {
-        group = "github-runners";
-        mode = "0440";
-      };
-      sops.secrets."github-runners/aws-access-key-id" = {
-        group = "github-runners";
-        mode = "0440";
-      };
-      sops.secrets."github-runners/aws-secret-access-key" = {
-        group = "github-runners";
-        mode = "0440";
-      };
+      users.groups.github-runner = { };
+      sops.secrets."github-runners/pat".owner = "github-runner";
+      sops.secrets."github-runners/age-key".owner = "github-runner";
+      sops.secrets."github-runners/aws-access-key-id".owner = "github-runner";
+      sops.secrets."github-runners/aws-secret-access-key".owner = "github-runner";
       sops.templates."state-backend-secrets" = {
-        owner = "root";
-        group = "github-runners";
-        mode = "0440";
+        owner = "github-runner";
         content = ''
           AWS_ACCESS_KEY_ID=${config.sops.placeholder."github-runners/aws-access-key-id"}
           AWS_SECRET_ACCESS_KEY=${config.sops.placeholder."github-runners/aws-secret-access-key"}
         '';
       };
-      # Allow members of the github-runners group to use the nix daemon
-      nix.settings.trusted-users = [ "@github-runners" ];
+      # Allow the runner user to use the nix daemon
+      nix.settings.trusted-users = [ "github-runner" ];
 
       services.github-runners = builtins.listToAttrs (
         map (num: {
           name = "nixos-runner-${toString num}";
           value = {
             enable = true;
+            # Run as a static user (disables DynamicUser). Required so the
+            # disk-backed workDir below is a real path, not a /var/cache/private
+            # symlink — see the users.users.github-runner comment above.
+            user = "github-runner";
+            group = "github-runner";
             # Default workDir is the systemd RuntimeDirectory under /run (tmpfs),
             # which is RAM-backed and small — builds fill it up. Use a disk-backed
             # CacheDirectory instead (see serviceOverrides), which systemd creates
-            # and chowns to the runner's dynamic user on every start. It's a
-            # reconstructable checkout (wiped each start), so cache, not state.
+            # and chowns to the runner user each start. It's a reconstructable
+            # checkout (wiped each start), so cache, not state.
             workDir = workDirFor num;
-            # Changing workDir triggers a new registration; without replace the
-            # re-registration under the same name fails.
+            # Changing workDir/user triggers a new registration; without replace
+            # the re-registration under the same name fails.
             replace = true;
             url = "https://github.com/britter/home-lab";
             tokenType = "access";
@@ -66,19 +64,15 @@ _: {
               "x86_64"
             ];
             serviceOverrides = {
-              # CacheDirectory for the workDir above. systemd creates it on disk
-              # under /var/cache and, under DynamicUser, chowns it to the runner's
-              # dynamic user each start, so $HOME (= workDir) is owned by the runner
-              # and stays writable under ProtectSystem=strict.
+              # CacheDirectory for the workDir above. With a static user systemd
+              # creates it as a real dir at /var/cache/github-runners/<name>
+              # (no /private symlink), chowned to the runner user, writable under
+              # ProtectSystem=strict.
               CacheDirectory = [ (cacheSubdir num) ];
-              # A managed *Directory already implies its own BindPaths=; the module
-              # adds a second BindPaths=[workDir] for custom workDirs, which collides
-              # with that and shadows the chowned dir with a root-owned mount (ln in
-              # setup-work-dirs then fails with EACCES). systemd docs also say not to
-              # combine BindPaths= with DynamicUser=. Clear it so CacheDirectory owns
-              # the dir outright, mirroring the default RuntimeDirectory code path.
+              # CacheDirectory already implies its own BindPaths=; the module adds
+              # a second, redundant BindPaths=[workDir] for custom workDirs. Clear
+              # it so CacheDirectory manages the dir outright.
               BindPaths = lib.mkForce [ ];
-              SupplementaryGroups = [ "github-runners" ];
               EnvironmentFile = [ config.sops.templates.state-backend-secrets.path ];
               Environment = [
                 "SOPS_AGE_KEY_FILE=${config.sops.secrets."github-runners/age-key".path}"


### PR DESCRIPTION
## Summary

Follow-up to #254 / #255. After moving the workDir to a `CacheDirectory`, `actions/checkout` failed with `fatal: could not read Username for 'https://github.com'`.

**Cause:** the runners run as `DynamicUser`, so systemd creates the `CacheDirectory` under `/var/cache/private/...` with a symlink at `/var/cache/...`. `actions/checkout` v6 writes git credentials via `includeIf.gitdir:<workDir>`, but git resolves that symlink when evaluating the `gitdir` condition, so it never matches, the credentials file is never loaded, and the fetch falls back to a username prompt. This is [actions/checkout#2393](https://github.com/actions/checkout/issues/2393). It worked before only because the old `RuntimeDirectory` workDir (`/run`) is a real path with no `/private` symlink.

Any persistent systemd-managed dir under `DynamicUser` gets that symlink, so `DynamicUser` and a disk-backed workDir are mutually exclusive here. Prior art ([nix-darwin](https://github.com/nix-darwin/nix-darwin/blob/master/modules/services/github-runner/service.nix), [juspay/github-nix-ci](https://github.com/juspay/github-nix-ci/blob/main/nix/module.nix)) all pair a disk workDir with a static user.

**Fix:** give the runners a shared `github-runner` system user (`DynamicUser=false`), so the `CacheDirectory` is a real `/var/cache/github-runners/<name>` dir chowned to that user and `includeIf.gitdir` matches.

Drive-by cleanups, now that a dedicated user reads the secrets:
- sops secrets/template use `owner = "github-runner"` instead of the group + `0440` dance;
- trusted nix user named directly instead of via `@github-runners`;
- renamed the now-single-purpose group `github-runners` → `github-runner`.

## ⚠️ One-time host cleanup on srv-prod-6

systemd leaves already-existing dirs untouched, so the stale `DynamicUser` dirs from the previous deploy must be removed once, or the runner keeps seeing the old root-owned/symlinked layout:

```
rm -rf /var/cache/private/github-runners/* /var/cache/github-runners/* \
       /var/lib/private/github-runner/*
```

Once [actions/checkout#2393](https://github.com/actions/checkout/issues/2393) is fixed and released, the `DynamicUser` approach would work again and this could be reverted — but the static user is fine to keep.

Ref: [actions/checkout#2393](https://github.com/actions/checkout/issues/2393)