### PR TITLE
it-tools: serve on srv-prod-6 at tools.ritter.family

### DIFF
--- a/modules/hosts/directions/services/https-proxy.nix
+++ b/modules/hosts/directions/services/https-proxy.nix
@@ -90,6 +90,10 @@ _: {
             '';
           }
           {
+            fqdn = "tools.ritter.family";
+            target = "https://tools.srv-prod-6.ritter.family";
+          }
+          {
             fqdn = "unifi.ritter.family";
             target = "https://192.168.1.1";
             proxyWebsockets = true;

--- a/modules/hosts/srv-prod-6/configuration.nix
+++ b/modules/hosts/srv-prod-6/configuration.nix
@@ -6,6 +6,7 @@
       proxmox-vm
       tailscale-server
       beszel-agent
+      it-tools
       forgejo-on-srv-prod-6
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
       (config.flake.factory.github-runners { count = 4; })

--- a/modules/nixos/gatus.nix
+++ b/modules/nixos/gatus.nix
@@ -90,6 +90,14 @@ _: {
                 "[BODY].status == pass"
               ];
             }
+            {
+              name = "IT Tools";
+              url = "https://tools.ritter.family";
+              interval = "5m";
+              conditions = [
+                "[STATUS] == 200"
+              ];
+            }
           ];
         };
       };

--- a/modules/nixos/homepage.nix
+++ b/modules/nixos/homepage.nix
@@ -88,6 +88,13 @@ _: {
                 icon = "forgejo.svg";
               };
             }
+            {
+              "IT Tools" = {
+                description = "Collection of handy online tools for developers";
+                href = "https://tools.ritter.family/";
+                icon = "it-tools.svg";
+              };
+            }
           ];
         }
         {

--- a/modules/nixos/it-tools.nix
+++ b/modules/nixos/it-tools.nix
@@ -1,0 +1,19 @@
+_: {
+  flake.modules.nixos.it-tools =
+    { config, pkgs, ... }:
+    let
+      fqdn = "tools.${config.networking.hostName}.ritter.family";
+    in
+    {
+      services.https-proxy = {
+        enable = true;
+        configurations = [ { inherit fqdn; } ]; # target null → TLS vhost only
+      };
+
+      services.nginx.virtualHosts.${fqdn} = {
+        root = "${pkgs.it-tools}/lib";
+        # SPA: vue-router history mode → fall back to index.html for deep links
+        locations."/".tryFiles = "$uri $uri/ /index.html";
+      };
+    };
+}


### PR DESCRIPTION
## Summary
- Serve the `it-tools` nixpkgs package as a static site via nginx on srv-prod-6, exposed at `tools.srv-prod-6.ritter.family` through the existing `https-proxy` module (TLS/ACME vhost with `target = null`, static `root` merged onto the same vhost)
- Proxy `tools.ritter.family` → `tools.srv-prod-6.ritter.family` on the directions edge
- Add Gatus status check and a homepage tile (Development group)

No container/port/image pin — just the packaged static SPA. Forgejo on srv-prod-6 is unaffected (per-fqdn vhosts, additive `configurations`).

Manual follow-up: ensure public DNS `tools.ritter.family` resolves to the edge (likely covered by a `*.ritter.family` wildcard).