### PR TITLE
paperless: deploy on srv-prod-2 at documents.ritter.family

### DIFF
--- a/modules/hosts/directions/services/https-proxy.nix
+++ b/modules/hosts/directions/services/https-proxy.nix
@@ -23,6 +23,13 @@ _: {
             proxyWebsockets = true;
           }
           {
+            fqdn = "documents.ritter.family";
+            target = "https://documents.srv-prod-2.ritter.family";
+            extraConfig = ''
+              client_max_body_size 100M;
+            '';
+          }
+          {
             fqdn = "fritz-box.ritter.family";
             target = "https://${config.home-lab.devices.fritz-box.ip}";
           }

--- a/modules/hosts/srv-prod-2/configuration.nix
+++ b/modules/hosts/srv-prod-2/configuration.nix
@@ -10,6 +10,7 @@
       calibre-web-on-srv-prod-2
       git-server-on-srv-prod-2
       nextcloud-on-srv-prod-2
+      paperless-on-srv-prod-2
       vaultwarden-on-srv-prod-2
       (config.flake.factory.sops { secretsFile = ./secrets.yaml; })
     ];

--- a/modules/hosts/srv-prod-2/secrets.yaml
+++ b/modules/hosts/srv-prod-2/secrets.yaml
@@ -17,10 +17,16 @@ restic:
         repository-password: ENC[AES256_GCM,data:XHkINLS9/M/wXgz/OW05xodsukJOb5UASnYgTz+Z0yWQEIscjIV1lGgv06i8TUnfG4VsXoyppGsHIgc0+jf4lIs2rUh+Q9UuuxD7IT1MvdT6HHEFSo4vW5Z/h4PIj5yCkow44Yq3jKfqX+fYAP7VESA8FEocNv4O,iv:7BoHdUcDHXfGuoaKthhX0CY6AZTGSEjR8SKbB4y94o4=,tag:+3+X8aWqzHsGWcI2zaAOyA==,type:str]
         minio-access-key-id: ENC[AES256_GCM,data:RwSNUfPPFeT1MsAuFnHZTSuYjXY=,iv:I/5WtpjxfYJoRQebw4vaoinGD9Q6nB00xxvr7zu3LZM=,tag:K0jL2w4gIY4WG5NhJLzr4Q==,type:str]
         minio-secret-access-key: ENC[AES256_GCM,data:b7K/tdx0sJ+LGPpEAhAUvv2j35oAJDCOPK4LItnM3AQXHbF7dMZIwA==,iv:HIxLzbl+5wa+8XNDLXraVxq2kJ+nPdkMYhJIbb/8tDg=,tag:5JIiKSV7UdCCoGbZ36Rdtw==,type:str]
+    paperless:
+        repository-password: ENC[AES256_GCM,data:fnSiULi5sUX8XkKJfEaA2vGuUR8u0wd7j2KY5zXmrjFdfQBXGR7kCFWDFk4EmA68SNKlFxkOKMMZE7MFOL1bAY618sIty+o9C5awudB99Cn6vAKH++6jjnEpvIJuGfZxyEPHXm9Jy7uF0B7+K0+pAlvsl0Cku6QD,iv:noxZGiU8g7tPlI9s3LkZcY7ef2a5JYLoczegS4fYwLA=,tag:NBFNmRJ+IzITMpv/OYk0bQ==,type:str]
+        minio-access-key-id: ENC[AES256_GCM,data:mXC2LQ4MQ0+TGzZlfazz5241LKo=,iv:H+D+uuGEsMH/z4PGzpYfAcAWa8XJ43BTVFSh82p4KM0=,tag:vycxxT/DBCJ9EPaKCli7Vg==,type:str]
+        minio-secret-access-key: ENC[AES256_GCM,data:ncfu+XYrdsEhYVhQMFErZV+9q+/lXUZgKgs4l9fuMgaePEs2JoK9zQ==,iv:F6swc3Tpbcdarz9C4Jes24Nrtk15WD0q9zNcA2REQcs=,tag:9RXpxlEN3p0ytd4x/x3uTw==,type:str]
     vaultwarden:
         repository-password: ENC[AES256_GCM,data:KRX7epJRObMohvZ6BWNIBuuf4IGZItX2BkQf5hSeczlsUaN0WJ5qry6JaiaPj3TigkceFyP4mGJwuqhAUhV+chRtl8k2TJm+WSnUMt+xnaV7ziPetCSST8WxlsuiVNNLFQQk9L+wwuXVwsqXIBNAJ9TjqU9e+SBg,iv:6WUIcLO7uOzkLXv7IwB4ty6z1p6Gjo7CCSWqBghjWMY=,tag:awbGL1LrKiZq5HIFsP9FiA==,type:str]
         minio-access-key-id: ENC[AES256_GCM,data:UbdsOAcgLKxyympDzIS7nNLmMsk=,iv:eTjJ9v8kh7TuIYAW4BJsE+6rrVpJgl7b2NeB5VR10wM=,tag:0W6AgOs3E5jwaeu/h6aXZg==,type:str]
         minio-secret-access-key: ENC[AES256_GCM,data:eR9scS/VxG5rBpt8vndsj/TShzIOnJc/ANX80/kg1iCTcU5hS150nw==,iv:qvJXz++p5mJ0spFWQ0GmgI1e07a0SEikm7nRcbCLSqg=,tag:VBiw9Cr9a7YBEQDoeaJoCA==,type:str]
+paperless:
+    admin-password: ENC[AES256_GCM,data:GZ3wkdVsx/jhGsBKSjUryREQKF0VTT+S0Gelswwcy5VQAdqDaIVh9/zb,iv:YgHl27M5dodJcyZQahUeAUnD/SHfKlT/ei2eE+WO/yk=,tag:GNeXLcHdMkudpKGoRyA+7w==,type:str]
 tailscale:
     auth-key: ENC[AES256_GCM,data:HJQDin4h53rYD8Emaq9dXhSohezLz7g/sVKMI3TaWd34jtShoWRjN6jm9zFyYp95fMenUPTRcFS+Ei0/+Vw=,iv:snunAmf5jOjDFXR6QYGo4XFZSaci8UcwRWx0cRtK0gw=,tag:cZTjRcAuZllcXQFAduYykQ==,type:str]
 vaultwarden:
@@ -47,7 +53,7 @@ sops:
             UA66wmfGTRhs/42MF7YOwCLOMBQ/NINUm+X9AsdagnpVCunwydn6Vw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1auwa57jefln7sfelfx8l3sfacpwt3t2fxqch8643jyht7mtjwqzq8yxjzq
-    lastmodified: "2026-06-27T08:31:36Z"
-    mac: ENC[AES256_GCM,data:widHa3pRHcg4JgWEt8RLXwg6OW+dFNtcmoqMWzQcmHP3CpLEeL/FxJZdlfmKzSjSkMtPd+RAPiGc8rxg/+K/Ihs9bxuw5PB0Oe7B8xmh+51tVG0iwTl2SMMNhOOdTCV2xxTQ/sRnjFXR4PrfC2zhjK9tSWr1ymmSt6P//uj1IoY=,iv:E8ub7UbMwgDRyuwJYTgU9rAw7/MP3bDgZ4ysQq6Ec+8=,tag:n7gU7+6rujBG7HvPSwHakQ==,type:str]
+    lastmodified: "2026-07-11T09:04:22Z"
+    mac: ENC[AES256_GCM,data:vZCgWC8XaWRFAwaPyo5cvngDyukmm2xqafRvnMggMT57/dtEjXlG9D/Ue9gVSfogBjaKnUVumN2XbWBmWabFyGcXnrjml4Ps/u4RYfPT+VnUYbBdbDCCYEwGkyYVe+wiA9ey/VZxRtgBf8ybEwQ5EVgn4QI0ZFRqUEPlwaCtGPM=,iv:ZZ9//XyRtefttlspWr2B7IJndekmybF7vwtHxeWJ0g8=,tag:77R3CRlOIXIh3CGyE0ASCQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/modules/hosts/srv-prod-2/services/paperless.nix
+++ b/modules/hosts/srv-prod-2/services/paperless.nix
@@ -1,0 +1,66 @@
+{ config, ... }:
+let
+  inherit (config.flake.modules.nixos) paperless;
+  restic = import ./_restic-constants.nix;
+in
+{
+  flake.modules.nixos.paperless-on-srv-prod-2 =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      imports = [ paperless ];
+
+      boot.supportedFilesystems = [ "nfs" ];
+      fileSystems."/srv/paperless-media" = {
+        fsType = "nfs";
+        device = "storage.ritter.family:/mnt/default-pool/paperless";
+      };
+      services.paperless.mediaDir = "/srv/paperless-media";
+
+      # Gate every paperless unit that touches the media dir on the NFS mount.
+      systemd.services.paperless-web.unitConfig.RequiresMountsFor = "/srv/paperless-media";
+      systemd.services.paperless-consumer.unitConfig.RequiresMountsFor = "/srv/paperless-media";
+      systemd.services.paperless-scheduler.unitConfig.RequiresMountsFor = "/srv/paperless-media";
+      systemd.services.paperless-task-queue.unitConfig.RequiresMountsFor = "/srv/paperless-media";
+
+      systemd.tmpfiles.rules = [
+        "d /var/backups/paperless 0755 postgres postgres"
+      ];
+
+      sops.secrets."restic/paperless/repository-password" = { };
+      sops.secrets."restic/paperless/minio-access-key-id" = { };
+      sops.secrets."restic/paperless/minio-secret-access-key" = { };
+      sops.templates."restic/paperless/secrets.env" = {
+        content = ''
+          AWS_ACCESS_KEY_ID=${config.sops.placeholder."restic/paperless/minio-access-key-id"}
+          AWS_SECRET_ACCESS_KEY=${config.sops.placeholder."restic/paperless/minio-secret-access-key"}
+          RESTIC_PASSWORD=${config.sops.placeholder."restic/paperless/repository-password"}
+        '';
+      };
+
+      services.restic.backups.paperless =
+        let
+          pg_dump = "${config.services.postgresql.package}/bin/pg_dump";
+        in
+        {
+          environmentFile = config.sops.templates."restic/paperless/secrets.env".path;
+          paths = [
+            "/srv/paperless-media"
+            "/var/backups/paperless"
+          ];
+          repository = "${restic.bucket}/paperless";
+          initialize = true;
+          backupPrepareCommand = ''
+            ${lib.getExe pkgs.sudo} -u postgres ${pg_dump} --format=custom --file=/var/backups/paperless/paperless.dump paperless
+          '';
+          backupCleanupCommand = ''
+            rm -f /var/backups/paperless/paperless.dump
+          '';
+          inherit (restic) pruneOpts timerConfig;
+        };
+    };
+}

--- a/modules/nixos/gatus.nix
+++ b/modules/nixos/gatus.nix
@@ -98,6 +98,14 @@ _: {
                 "[STATUS] == 200"
               ];
             }
+            {
+              name = "Paperless";
+              url = "https://documents.ritter.family/accounts/login/";
+              interval = "5m";
+              conditions = [
+                "[STATUS] == 200"
+              ];
+            }
           ];
         };
       };

--- a/modules/nixos/homepage.nix
+++ b/modules/nixos/homepage.nix
@@ -52,6 +52,13 @@ _: {
                 icon = "vaultwarden.svg";
               };
             }
+            {
+              "Paperless" = {
+                description = "Document management system";
+                href = "https://documents.ritter.family/";
+                icon = "paperless-ngx.svg";
+              };
+            }
           ];
         }
         {

--- a/modules/nixos/paperless.nix
+++ b/modules/nixos/paperless.nix
@@ -1,0 +1,33 @@
+_: {
+  flake.modules.nixos.paperless =
+    { config, ... }:
+    {
+      sops.secrets."paperless/admin-password" = { };
+
+      services.paperless = {
+        enable = true;
+        port = 28981; # default; referenced by the proxy target below
+        database.createLocally = true; # use the local postgres already running on this host
+        passwordFile = config.sops.secrets."paperless/admin-password".path;
+        settings = {
+          PAPERLESS_URL = "https://documents.ritter.family"; # required for CSRF/redirects behind proxy
+          PAPERLESS_TIME_ZONE = "Europe/Berlin";
+          PAPERLESS_OCR_LANGUAGE = "deu+eng"; # nixpkgs module auto-builds tesseract5 with these langs
+        };
+      };
+
+      services.https-proxy = {
+        enable = true;
+        configurations = [
+          {
+            fqdn = "documents.${config.networking.hostName}.ritter.family";
+            aliases = [ "documents.ritter.family" ];
+            target = "http://localhost:28981";
+            extraConfig = ''
+              client_max_body_size 100M;
+            '';
+          }
+        ];
+      };
+    };
+}


### PR DESCRIPTION
## Summary

Deploys paperless-ngx on `srv-prod-2`, reachable at `https://documents.ritter.family`.

- **Generic module** `modules/nixos/paperless.nix` — `services.paperless` (PostgreSQL via `database.createLocally`, port 28981, `deu+eng` OCR), local https-proxy vhost, and the `paperless/admin-password` sops secret.
- **Host wrapper** `modules/hosts/srv-prod-2/services/paperless.nix` — documents stored on NFS (`/srv/paperless-media` ← `storage.ritter.family:/mnt/default-pool/paperless`, units gated with `RequiresMountsFor`), plus a nightly restic backup to MinIO (`pg_dump` + media dir), matching nextcloud/vaultwarden.
- **Public routing** — `documents.ritter.family` added to the `directions` gateway proxy.
- **Observability** — Gatus endpoint and a Homepage tile in the Office group.

Uses the local Postgres already running on this VM (nextcloud/vaultwarden) rather than SQLite — paperless runs multiple concurrent worker processes and its docs recommend Postgres.

## Before deploy

- Create the NFS export `/mnt/default-pool/paperless` on `storage.ritter.family` (same pattern as nextcloud/immich/navidrome).
- Secret values (`paperless/admin-password`, `restic/paperless/*`) added out of band via sops.