### PR TITLE
it-tools: fix tools.ritter.family falling through to forgejo

### DIFF
--- a/modules/nixos/it-tools.nix
+++ b/modules/nixos/it-tools.nix
@@ -7,7 +7,15 @@ _: {
     {
       services.https-proxy = {
         enable = true;
-        configurations = [ { inherit fqdn; } ]; # target null → TLS vhost only
+        # alias so the edge proxy's preserved Host header (tools.ritter.family)
+        # matches here; without it the request falls through to the default vhost
+        # (forgejo) since srv-prod-6 hosts more than one vhost. target null → TLS vhost only.
+        configurations = [
+          {
+            inherit fqdn;
+            aliases = [ "tools.ritter.family" ];
+          }
+        ];
       };
 
       services.nginx.virtualHosts.${fqdn} = {


### PR DESCRIPTION
## Summary
Follow-up to #257. The public `tools.ritter.family` fell through to forgejo while `tools.srv-prod-6.ritter.family` worked.

The directions edge proxy preserves the `Host` header, so requests reach srv-prod-6 as `tools.ritter.family`. The backend vhost only answered to `tools.srv-prod-6.ritter.family`, and since srv-prod-6 hosts more than one vhost, the unmatched Host fell through to the default vhost (forgejo). Adding `aliases = [ "tools.ritter.family" ]` — the same pattern forgejo/stirling-pdf already use — makes the backend vhost match.