### PR TITLE
https-proxy: promote maxBodySize/proxyTimeout/buffering options

### DIFF
--- a/modules/hosts/directions/services/https-proxy.nix
+++ b/modules/hosts/directions/services/https-proxy.nix
@@ -13,9 +13,7 @@ _: {
           {
             fqdn = "books.ritter.family";
             target = "https://books.srv-prod-2.ritter.family";
-            extraConfig = ''
-              client_max_body_size 512M;
-            '';
+            maxBodySize = "512M";
           }
           {
             fqdn = "collabora.ritter.family";
@@ -25,9 +23,7 @@ _: {
           {
             fqdn = "documents.ritter.family";
             target = "https://documents.srv-prod-2.ritter.family";
-            extraConfig = ''
-              client_max_body_size 100M;
-            '';
+            maxBodySize = "100M";
           }
           {
             fqdn = "fritz-box.ritter.family";
@@ -36,9 +32,7 @@ _: {
           {
             fqdn = "git.ritter.family";
             target = "https://git.srv-prod-6.ritter.family";
-            extraConfig = ''
-              client_max_body_size 512M;
-            '';
+            maxBodySize = "512M";
           }
           {
             fqdn = "grafana.ritter.family";
@@ -61,29 +55,21 @@ _: {
           {
             fqdn = "nextcloud.ritter.family";
             target = "https://nextcloud.srv-prod-2.ritter.family";
-            extraConfig = ''
-              client_max_body_size 512M;
-            '';
+            maxBodySize = "512M";
           }
           {
             fqdn = "photos.ritter.family";
             target = "https://photos.srv-prod-4.ritter.family";
             proxyWebsockets = true;
-            extraConfig = ''
-              client_max_body_size 50000M;
-              proxy_read_timeout   600s;
-              proxy_send_timeout   600s;
-              send_timeout         600s;
-            '';
+            maxBodySize = "50000M";
+            proxyTimeout = "600s";
           }
           {
             fqdn = "pve.ritter.family";
             target = "https://${config.home-lab.hypervisors.pve.ip}:8006";
-            extraConfig = ''
-              # Avoid buffering issues with the Proxmox task log stream
-              proxy_buffering off;
-              proxy_read_timeout 3600s; 
-            '';
+            # Avoid buffering issues with the Proxmox task log stream
+            buffering = false;
+            proxyTimeout = "3600s";
           }
           {
             fqdn = "passwords.ritter.family";

--- a/modules/nixos/calibre-web.nix
+++ b/modules/nixos/calibre-web.nix
@@ -27,9 +27,7 @@ _: {
             fqdn = "books.${config.networking.hostName}.ritter.family";
             aliases = [ "books.ritter.family" ];
             target = "http://localhost:8083";
-            extraConfig = ''
-              client_max_body_size 100M;
-            '';
+            maxBodySize = "100M";
           }
         ];
       };

--- a/modules/nixos/forgejo.nix
+++ b/modules/nixos/forgejo.nix
@@ -37,9 +37,7 @@ _: {
             fqdn = "git.${config.networking.hostName}.ritter.family";
             aliases = [ "git.ritter.family" ];
             target = "http://localhost:3000";
-            extraConfig = ''
-              client_max_body_size 512M;
-            '';
+            maxBodySize = "512M";
           }
         ];
       };

--- a/modules/nixos/https-proxy.nix
+++ b/modules/nixos/https-proxy.nix
@@ -20,6 +20,21 @@ _: {
             type = lib.types.bool;
             default = false;
           };
+          maxBodySize = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = ''client_max_body_size value, e.g. "512M" or "0" for unlimited.'';
+          };
+          proxyTimeout = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = ''Sets proxy_read_timeout, proxy_send_timeout and send_timeout, e.g. "600s".'';
+          };
+          buffering = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "When false, disables proxy_buffering (for streaming backends).";
+          };
           extraConfig = lib.mkOption {
             type = lib.types.lines;
             default = "";
@@ -47,7 +62,16 @@ _: {
           let
             makeHost = conf: {
               ${conf.fqdn} = {
-                inherit (conf) extraConfig;
+                extraConfig = lib.concatStrings [
+                  (lib.optionalString (conf.maxBodySize != null) "client_max_body_size ${conf.maxBodySize};\n")
+                  (lib.optionalString (conf.proxyTimeout != null) ''
+                    proxy_read_timeout ${conf.proxyTimeout};
+                    proxy_send_timeout ${conf.proxyTimeout};
+                    send_timeout ${conf.proxyTimeout};
+                  '')
+                  (lib.optionalString (!conf.buffering) "proxy_buffering off;\n")
+                  conf.extraConfig
+                ];
                 serverAliases = conf.aliases;
                 useACMEHost = conf.fqdn;
                 forceSSL = true;

--- a/modules/nixos/immich.nix
+++ b/modules/nixos/immich.nix
@@ -18,12 +18,8 @@ _: {
             fqdn = "photos.${config.networking.hostName}.ritter.family";
             target = "http://localhost:2283";
             proxyWebsockets = true;
-            extraConfig = ''
-              client_max_body_size 50000M;
-              proxy_read_timeout   600s;
-              proxy_send_timeout   600s;
-              send_timeout         600s;
-            '';
+            maxBodySize = "50000M";
+            proxyTimeout = "600s";
           }
         ];
       };

--- a/modules/nixos/minio.nix
+++ b/modules/nixos/minio.nix
@@ -35,14 +35,12 @@ _: {
             inherit fqdn;
             target = "http://localhost:9000";
             proxyWebsockets = true;
+            # Allow any size file to be uploaded.
+            maxBodySize = "0";
+            buffering = false;
             extraConfig = ''
               # Allow special characters in headers
               ignore_invalid_headers off;
-              # Allow any size file to be uploaded.
-              # Set to a value such as 1000m; to restrict file size to a specific value
-              client_max_body_size 0;
-              # Disable buffering
-              proxy_buffering off;
               proxy_request_buffering off;
               proxy_connect_timeout 300;
               chunked_transfer_encoding off;

--- a/modules/nixos/paperless.nix
+++ b/modules/nixos/paperless.nix
@@ -23,9 +23,7 @@ _: {
             fqdn = "documents.${config.networking.hostName}.ritter.family";
             aliases = [ "documents.ritter.family" ];
             target = "http://localhost:28981";
-            extraConfig = ''
-              client_max_body_size 100M;
-            '';
+            maxBodySize = "100M";
           }
         ];
       };

--- a/modules/nixos/stirling-pdf.nix
+++ b/modules/nixos/stirling-pdf.nix
@@ -29,9 +29,7 @@ _: {
             fqdn = "pdf.${config.networking.hostName}.ritter.family";
             aliases = [ "pdf.ritter.family" ];
             target = "http://localhost:8090";
-            extraConfig = ''
-              client_max_body_size 100M;
-            '';
+            maxBodySize = "100M";
           }
         ];
       };


### PR DESCRIPTION


Raw nginx directives leaked into `services.https-proxy.configurations` via the `extraConfig` escape hatch — `client_max_body_size` alone appeared in 12 call sites. This promotes the recurring directives to typed, backend-agnostic options:

- `maxBodySize` → `client_max_body_size`
- `proxyTimeout` → `proxy_read_timeout` + `proxy_send_timeout` + `send_timeout`
- `buffering` (default `true`) → emits `proxy_buffering off` when `false`

They render into the vhost's server-level `extraConfig` (same placement as before), with the raw `extraConfig` kept as the escape hatch.

`extraConfig` is removed from 11 of 12 sites (calibre-web, stirling-pdf, paperless, forgejo, immich, and the directions edge entries books/documents/git/nextcloud/pdf/photos/pve). Only **minio** keeps a trimmed `extraConfig` for its S3-specific one-offs (`ignore_invalid_headers`, `proxy_request_buffering`, `proxy_connect_timeout`, `chunked_transfer_encoding`).

Verified semantically equivalent by diffing the rendered per-vhost `extraConfig` on all affected hosts — identical modulo whitespace/ordering, except `pve` now also gets `proxy_send_timeout`/`send_timeout` at 3600s (harmless, longer than nginx defaults).