### PR TITLE
noctalia: migrate from v4 to v5

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -36,6 +36,10 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
+        with:
+          extra-conf: |
+            extra-substituters = https://noctalia.cachix.org
+            extra-trusted-public-keys = noctalia.cachix.org-1:pCOR47nnMEo5thcxNDtzWpOxNFQsBRglJzxWPp3dkU4=
       - run: nix build .#nixosConfigurations.${{ matrix.configuration }}.config.system.build.toplevel
   build-iso:
     name: Build ISOs
@@ -43,6 +47,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
+        with:
+          extra-conf: |
+            extra-substituters = https://noctalia.cachix.org
+            extra-trusted-public-keys = noctalia.cachix.org-1:pCOR47nnMEo5thcxNDtzWpOxNFQsBRglJzxWPp3dkU4=
       - run: nix build .#nixosConfigurations.minimal-server-iso.config.system.build.isoImage
   build-home-manager:
     name: Build standalone home-manager config
@@ -55,4 +63,8 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
+        with:
+          extra-conf: |
+            extra-substituters = https://noctalia.cachix.org
+            extra-trusted-public-keys = noctalia.cachix.org-1:pCOR47nnMEo5thcxNDtzWpOxNFQsBRglJzxWPp3dkU4=
       - run: nix build .#homeConfigurations.${{ matrix.configuration }}.activationPackage

--- a/flake.lock
+++ b/flake.lock
@@ -324,6 +324,19 @@
     },
     "nixpkgs_5": {
       "locked": {
+        "lastModified": 1783522502,
+        "narHash": "sha256-nFgG4gPQueCgP8LidXsdI2lYPrSwTcmDl6afcVn7F/U=",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1031299.0bb7ec54c848/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
         "lastModified": 1783776592,
         "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
@@ -338,7 +351,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1782175435,
         "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
@@ -378,53 +391,26 @@
     },
     "noctalia": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "noctalia-qs": "noctalia-qs"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1783017890,
-        "narHash": "sha256-bAzrtN0GDMH0dOZkgeI3zSxfFs2rdD3pMuzOxvTF0bs=",
+        "lastModified": 1783941338,
+        "narHash": "sha256-9/V6dIgsFVsEJZ/mU1oxuvmt5L5Ez/7C0SbIDI8ElXU=",
         "owner": "noctalia-dev",
-        "repo": "noctalia-shell",
-        "rev": "a48885b9fec485c903c955749a7da6e30147cd38",
+        "repo": "noctalia",
+        "rev": "18d63aee7ab75dd3cbae41c4f49feba643519c2c",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "legacy-v4",
-        "repo": "noctalia-shell",
-        "type": "github"
-      }
-    },
-    "noctalia-qs": {
-      "inputs": {
-        "nixpkgs": [
-          "noctalia",
-          "nixpkgs"
-        ],
-        "systems": "systems_2",
-        "treefmt-nix": "treefmt-nix_3"
-      },
-      "locked": {
-        "lastModified": 1780799499,
-        "narHash": "sha256-YloRtLqJabzYUWvdLyh67zH4DZrR3kQj+dlQJwLPmPM=",
-        "owner": "noctalia-dev",
-        "repo": "noctalia-qs",
-        "rev": "f308426239665e3bc3d624014e9295b2ae2f58ff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "noctalia-dev",
-        "repo": "noctalia-qs",
+        "repo": "noctalia",
         "type": "github"
       }
     },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1783911225,
@@ -477,12 +463,12 @@
         "nur": "nur",
         "pre-commit-hooks": "pre-commit-hooks",
         "sops-nix": "sops-nix",
-        "treefmt-nix": "treefmt-nix_4"
+        "treefmt-nix": "treefmt-nix_3"
       }
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1783174389,
@@ -511,21 +497,6 @@
         "owner": "nix-systems",
         "ref": "future-26.11",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default-linux",
         "type": "github"
       }
     },
@@ -569,28 +540,6 @@
       }
     },
     "treefmt-nix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "noctalia",
-          "noctalia-qs",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_4": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -28,10 +28,9 @@
       url = "github:nix-community/nixvim";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    noctalia = {
-      url = "github:noctalia-dev/noctalia-shell/legacy-v4";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # No `nixpkgs.follows`: overriding noctalia's inputs changes the derivation
+    # hash and misses their binary cache (https://noctalia.cachix.org).
+    noctalia.url = "github:noctalia-dev/noctalia";
     nur.url = "github:nix-community/NUR";
     pre-commit-hooks = {
       url = "github:cachix/git-hooks.nix";

--- a/modules/home/desktop/sway/noctalia.nix
+++ b/modules/home/desktop/sway/noctalia.nix
@@ -5,6 +5,14 @@
     hardware.bluetooth.enable = true;
     services.power-profiles-daemon.enable = true;
     services.upower.enable = true;
+
+    # Pull noctalia from its binary cache instead of compiling it.
+    nix.settings = {
+      extra-substituters = [ "https://noctalia.cachix.org" ];
+      extra-trusted-public-keys = [
+        "noctalia.cachix.org-1:pCOR47nnMEo5thcxNDtzWpOxNFQsBRglJzxWPp3dkU4="
+      ];
+    };
   };
 
   flake.modules.homeManager.noctalia =
@@ -12,77 +20,62 @@
     {
       imports = [ inputs.noctalia.homeModules.default ];
 
-      programs.noctalia-shell = {
+      programs.noctalia = {
         enable = true;
-        package = pkgs.noctalia-shell;
+        # The v5 home module registers no overlay, so pkgs.noctalia is absent;
+        # take the package straight from the flake input.
+        package = inputs.noctalia.packages.${pkgs.system}.default;
         settings = {
-          bar = {
-            outerCorners = false;
-            widgets = {
-              left = [
-                { id = "Workspace"; }
-                { id = "MediaMini"; }
-              ];
-              center = [
-                { id = "Clock"; }
-                { id = "NotificationHistory"; }
-              ];
-              right = [
-                { id = "Tray"; }
-                { id = "SystemMonitor"; }
-                { id = "Battery"; }
-                { id = "Volume"; }
-                { id = "Brightness"; }
-                { id = "ControlCenter"; }
-              ];
-            };
+          theme = {
+            source = "builtin";
+            builtin = "Catppuccin";
           };
-          appLauncher = {
-            terminalCommand = "${pkgs.ghostty} -e";
-            enableClipboardHistory = true;
-          };
-          dock.enable = false;
-          sessionMenu = {
-            enableCountdown = false;
-            largeButtonsStyle = false;
-            powerOptions = [
-              {
-                action = "lock";
-                enabled = true;
-                keybind = "l";
-              }
-              {
-                action = "suspend";
-                enabled = true;
-                keybind = "s";
-              }
-              {
-                action = "hibernate";
-                enabled = true;
-                keybind = "h";
-              }
-              {
-                action = "reboot";
-                enabled = true;
-                keybind = "r";
-              }
-              {
-                action = "logout";
-                enabled = true;
-                keybind = "e";
-              }
-              {
-                action = "shutdown";
-                enabled = true;
-                keybind = "p";
-              }
-              {
-                action = "rebootToUefi";
-                enabled = false;
-                keybind = "7";
-              }
+          bar.main = {
+            start = [
+              "workspaces"
+              "media"
+            ];
+            center = [
+              "clock"
+              "notifications"
+            ];
+            end = [
+              "tray"
+              "sysmon"
+              "battery"
+              "volume"
+              "brightness"
+              "control-center"
             ];
           };
+          dock.enabled = false;
+          shell.session.actions = [
+            {
+              action = "lock";
+              enabled = true;
+              shortcut = "l";
+            }
+            {
+              action = "suspend";
+              enabled = true;
+              shortcut = "s";
+            }
+            {
+              action = "reboot";
+              enabled = true;
+              shortcut = "r";
+            }
+            {
+              action = "logout";
+              enabled = true;
+              shortcut = "e";
+            }
+            {
+              action = "shutdown";
+              enabled = true;
+              shortcut = "p";
+            }
+          ];
         };
       };
     };

--- a/modules/home/desktop/sway/sway.nix
+++ b/modules/home/desktop/sway/sway.nix
@@ -50,8 +50,8 @@ in
     }:
     let
       screenshotsDir = "${config.home.homeDirectory}/Pictures/Screenshots";
-      ns = lib.getExe config.programs.noctalia-shell.package;
-      nsipc = "${ns} ipc call";
+      ns = lib.getExe config.programs.noctalia.package;
+      nsipc = "${ns} msg";
       capture-screenhot = pkgs.writeShellApplication {
         name = "capture-screenshot";
         runtimeInputs = [ pkgs.sway-contrib.grimshot ];
@@ -81,7 +81,7 @@ in
         wrapperFeatures.gtk = true;
         config = {
           startup = [ { command = ns; } ];
-          menu = "${nsipc} launcher toggle";
+          menu = "${nsipc} panel-toggle launcher";
           bars = [ { mode = "invisible"; } ];
           terminal = lib.getExe pkgs.ghostty;
           defaultWorkspace = "workspace number 1";
@@ -173,15 +173,15 @@ in
               "${mod}+Ctrl+x" = "exec ${lib.getExe capture-screenhot} area";
 
               # Custom modes
-              "${mod}+Escape" = "exec ${nsipc} sessionMenu toggle";
+              "${mod}+Escape" = "exec ${nsipc} panel-toggle session";
               "${mod}+p" = ''mode "present"'';
 
               # Fn functionality on F keys
-              "XF86AudioMute" = "exec ${nsipc} volume muteOutput";
-              "XF86AudioRaiseVolume" = "exec ${nsipc} volume increase";
-              "XF86AudioLowerVolume" = "exec ${nsipc} volume decrease";
-              "XF86MonBrightnessUp" = "exec ${nsipc} brightness increase";
-              "XF86MonBrightnessDown" = "exec ${nsipc} brightness decrease";
+              "XF86AudioMute" = "exec ${nsipc} volume-mute";
+              "XF86AudioRaiseVolume" = "exec ${nsipc} volume-up";
+              "XF86AudioLowerVolume" = "exec ${nsipc} volume-down";
+              "XF86MonBrightnessUp" = "exec ${nsipc} brightness-up";
+              "XF86MonBrightnessDown" = "exec ${nsipc} brightness-down";
             };
           modes = {
             # redeclare resize mode in order not to override it

--- a/modules/home/desktop/sway/wallpapers.nix
+++ b/modules/home/desktop/sway/wallpapers.nix
@@ -10,8 +10,7 @@
       };
     in
     {
-      home.file.".cache/noctalia/wallpapers.json".text = builtins.toJSON {
-        defaultWallpaper = "${catppuccin-wallpapers}/landscapes/Clearday.jpg";
-      };
+      programs.noctalia.settings.wallpaper.default.path =
+        "${catppuccin-wallpapers}/landscapes/Clearday.jpg";
     };
 }


### PR DESCRIPTION
## Summary

Migrate the framework-13 shell from noctalia-shell v4 to noctalia v5. v5 is a ground-up C++/OpenGL rewrite living in a new repo (`noctalia-dev/noctalia`), so this is a rewrite of the config rather than a version bump — there is no automatic settings migration.

- **Input** → `github:noctalia-dev/noctalia` (main). Dropped `inputs.nixpkgs.follows = "nixpkgs"` so the derivation hash matches upstream's binary cache instead of recompiling the C++ shell locally.
- **Cache** → enabled `https://noctalia.cachix.org` in the framework-13-scoped `nix.settings`. Verified the exact `default` package output resolves in the cache.
- **Module** → `programs.noctalia-shell` → `programs.noctalia`; package taken straight from the flake input (the v5 HM module registers no overlay).
- **Settings** → rewritten to the v5 TOML schema (verified against the v5.0.0-beta2 source, not just docs):
  - `bar.main.start/center/end` as string widget ids (`sysmon` for the system monitor, `notifications`, `control-center`).
  - `dock.enabled = false`; clipboard on by default (no setting needed); no launcher terminal command in v5 (auto-detected).
  - `shell.session.actions` with `shortcut` (v4's `hibernate`/`rebootToUefi` don't exist in v5 and were dropped).
  - builtin Catppuccin theme.
- **Wallpaper** → `settings.wallpaper.default.path` instead of the obsolete `~/.cache/noctalia/wallpapers.json`.
- **IPC** (sway keybinds) → `ipc call <target> <action>` → `msg …`: `panel-toggle launcher`, `panel-toggle session`, `volume-mute/up/down`, `brightness-up/down`.
- **Launch** → kept the sway `startup` exec; systemd activation is deprecated in v5.