### PR TITLE
kotlin-lsp: update to 262.8190.0

### DIFF
--- a/packages/kotlin-lsp/default.nix
+++ b/packages/kotlin-lsp/default.nix
@@ -3,17 +3,16 @@
   stdenvNoCC,
   fetchzip,
   makeWrapper,
-  jdk21,
+  jdk25,
   autoPatchelfHook,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "kotlin-lsp";
-  version = "262.2310.0";
+  version = "262.8190.0";
 
   src = fetchzip {
-    url = "https://download-cdn.jetbrains.com/kotlin-lsp/${finalAttrs.version}/kotlin-lsp-${finalAttrs.version}-linux-x64.zip";
-    sha256 = "sha256-Bf2qkFpNhQC/Mz563OapmCXeKN+dTrYyQbOcF6z6b48=";
-    stripRoot = false;
+    url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/${finalAttrs.version}/kotlin-server-${finalAttrs.version}.tar.gz";
+    sha256 = "sha256-kxV0AU1TEi7U84boc45V7GJNJzo3uWraHEo6q4Kd9+U=";
   };
 
   nativeBuildInputs = [
@@ -22,22 +21,39 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    jdk21
+    jdk25
     stdenv.cc.cc.lib
   ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,share}
-    cp -r lib native kotlin-lsp.sh $out/share
+    mkdir -p $out/bin $out/share/kotlin-lsp
+    cp -r bin build.txt kotlin-lsp.sh lib license modules plugins product-info.json $out/share/kotlin-lsp
+    ln -s ${jdk25}/lib/openjdk $out/share/kotlin-lsp/jbr
 
-    chmod +x $out/share/kotlin-lsp.sh
-    substituteInPlace $out/share/kotlin-lsp.sh \
-      --replace-fail 'LOCAL_JRE_PATH="$DIR/jre/Contents/Home"' 'LOCAL_JRE_PATH="${jdk21}"' \
-      --replace-fail 'LOCAL_JRE_PATH="$DIR/jre"' 'LOCAL_JRE_PATH="${jdk21}"'
-    makeWrapper $out/share/kotlin-lsp.sh $out/bin/kotlin-lsp
+    makeWrapper $out/share/kotlin-lsp/bin/intellij-server $out/bin/kotlin-lsp
 
     runHook postInstall
+  '';
+
+  # kotlin-lsp has no --version, so instead of versionCheckHook drive a
+  # minimal LSP initialize handshake over stdio and assert the server
+  # replies with a framed JSON-RPC message. This exercises the JVM launch
+  # and the patched native libraries, which is where breakage tends to hide.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    req='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}'
+    printf 'Content-Length: %d\r\n\r\n%s' "''${#req}" "$req" \
+      | timeout 120 $out/bin/kotlin-lsp --stdio > response.txt 2>/dev/null || true
+
+    grep -q '"jsonrpc"' response.txt || {
+      echo "kotlin-lsp did not respond to an LSP initialize request" >&2
+      exit 1
+    }
+
+    runHook postInstallCheck
   '';
 })


### PR DESCRIPTION
## Summary

Updates `kotlin-lsp` to the latest release, `262.8190.0`.

Newer releases ship the full IntelliJ-platform **kotlin-server** bundle instead of the old flat `kotlin-lsp` zip, so the derivation needed several structural changes:

- **Download** moved from `.../kotlin-lsp/VER/kotlin-lsp-VER-linux-x64.zip` to `.../language-server/kotlin-server/VER/kotlin-server-VER.tar.gz`.
- **Entrypoint** is now `bin/intellij-server`; `kotlin-lsp.sh` is deprecated and just `exec`s it, so we wrap the server directly.
- **JRE**: the bundle expects a `jbr/` dir and targets Java 25 (bundled JBR is 25.0.2), so we symlink nixpkgs `jdk25`'s `lib/openjdk` in as `jbr`.

Dropped the `autoPatchelfIgnoreMissingDeps = ["libc.musl-x86_64.so.1"]` from #169: no ELF in this version links against musl, and the build passes clean without it.

Also added an `installCheckPhase` in place of `versionCheckHook` (the LSP has no `--version`): it drives a minimal LSP `initialize` handshake over stdio and asserts the server replies with a framed JSON-RPC message, exercising the JVM launch and the patched native libraries.

Closes #169