### PR TITLE
nvim: add jsonnetfmt formatting source

### DIFF
--- a/modules/home/nvim/languages/jsonnet.nix
+++ b/modules/home/nvim/languages/jsonnet.nix
@@ -1,0 +1,25 @@
+_: {
+  flake.modules.homeManager.nvim =
+    { pkgs, ... }:
+    {
+      programs.nixvim.plugins.none-ls.luaConfig.post =
+        # lua
+        ''
+          do
+            local null_ls = require("null-ls")
+            local helpers = require("null-ls.helpers")
+
+            null_ls.register({
+              method = null_ls.methods.FORMATTING,
+              filetypes = { "jsonnet" },
+              name = "jsonnetfmt",
+              generator = helpers.formatter_factory({
+                command = "${pkgs.go-jsonnet}/bin/jsonnetfmt",
+                args = { "-" },
+                to_stdin = true,
+              }),
+            })
+          end
+        '';
+    };
+}


### PR DESCRIPTION
Register a none-ls formatting source for `jsonnet`/`libsonnet` files using `jsonnetfmt` from `go-jsonnet`.