### PR TITLE
nono: add sandbox module and nono-sandboxed opencode on framework-13

### DIFF
--- a/modules/home/ai-agent.nix
+++ b/modules/home/ai-agent.nix
@@ -25,7 +25,21 @@
 
       programs.opencode = {
         enable = true;
-        settings.plugin = [ "${ponytail}/.opencode/plugins/ponytail.mjs" ];
+        settings = {
+          plugin = [ "${ponytail}/.opencode/plugins/ponytail.mjs" ];
+
+          # A primary agent (cycle to it with Tab) that asks before mutations,
+          # like Claude Code's default. The built-in build agent is left as-is.
+          agent.careful = {
+            mode = "primary";
+            permission = {
+              edit = "ask";
+              bash = "ask";
+              webfetch = "ask";
+              external_directory = "ask";
+            };
+          };
+        };
       };
     };
 }

--- a/modules/home/ai-agent.nix
+++ b/modules/home/ai-agent.nix
@@ -1,0 +1,31 @@
+{
+  flake.modules.homeManager.ai-agent =
+    { pkgs, ... }:
+    let
+      nono-packs = pkgs.fetchFromGitHub {
+        owner = "nolabs-ai";
+        repo = "nono-packs";
+        rev = "6e54577b32a28cc9899e2bea6673bbe9c3ae1953";
+        hash = "sha256-+vaB+nmjYW9zYdHrGlgvV9m5GiRfQb3YO/S416YnWdM=";
+      };
+      # Zero-dependency opencode plugin; resolves its hooks/ and skills/
+      # relative to the .mjs, so we can run it straight from the pinned source.
+      ponytail = pkgs.fetchFromGitHub {
+        owner = "DietrichGebert";
+        repo = "ponytail";
+        rev = "v4.8.3";
+        hash = "sha256-4ZT89GA5xnomNBIzY8Kh1yYP0AC9SeVhv406DEKpE3A=";
+      };
+    in
+    {
+      programs.nono = {
+        enable = true;
+        packs."nolabs-ai/opencode".src = "${nono-packs}/opencode";
+      };
+
+      programs.opencode = {
+        enable = true;
+        settings.plugin = [ "${ponytail}/.opencode/plugins/ponytail.mjs" ];
+      };
+    };
+}

--- a/modules/home/nono.nix
+++ b/modules/home/nono.nix
@@ -1,0 +1,102 @@
+{
+  flake.modules.homeManager.nono =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.nono;
+      jsonFormat = pkgs.formats.json { };
+
+      # nono resolves `--profile <namespace>/<name>` from
+      # packages/<namespace>/<name>/profiles/<name>.json, which is the pack's
+      # policy.json renamed. Runtime needs no signature/lockfile, so we just lay
+      # the fetched pack out on disk with that one rename.
+      mkPack =
+        ref: pack:
+        let
+          profileName = lib.last (lib.splitString "/" ref);
+        in
+        pkgs.runCommand "nono-pack-${lib.replaceStrings [ "/" ] [ "-" ] ref}" { } ''
+          mkdir -p $out/profiles
+          cp -r ${pack.src}/. $out/
+          cp ${pack.src}/${pack.profileFile} $out/profiles/${profileName}.json
+        '';
+    in
+    {
+      options.programs.nono = {
+        enable = lib.mkEnableOption "nono capability-based sandbox";
+
+        package = lib.mkPackageOption pkgs "nono" { };
+
+        profiles = lib.mkOption {
+          type = lib.types.attrsOf jsonFormat.type;
+          default = { };
+          example = lib.literalExpression ''
+            {
+              my-agent = {
+                extends = "default";
+                groups.include = [ "deny_credentials" ];
+                workdir.access = "readwrite";
+              };
+            }
+          '';
+          description = ''
+            User profiles rendered to {file}`$XDG_CONFIG_HOME/nono/profiles/<name>.json`
+            and referenced as `nono run --profile <name>`.
+          '';
+        };
+
+        packs = lib.mkOption {
+          default = { };
+          description = ''
+            Registry packs placed on disk declaratively instead of via `nono pull`.
+            The attribute name is the pack reference (`<namespace>/<name>`) used with
+            `nono run --profile <namespace>/<name>`.
+          '';
+          example = lib.literalExpression ''
+            {
+              "nolabs-ai/opencode".src = "''${pkgs.fetchFromGitHub {
+                owner = "nolabs-ai";
+                repo = "nono-packs";
+                rev = "<commit>";
+                hash = "<sha256>";
+              }}/opencode";
+            }
+          '';
+          type = lib.types.attrsOf (
+            lib.types.submodule {
+              options = {
+                src = lib.mkOption {
+                  type = lib.types.path;
+                  description = "Pack directory containing the profile file (e.g. a fetchFromGitHub subpath).";
+                };
+                profileFile = lib.mkOption {
+                  type = lib.types.str;
+                  default = "policy.json";
+                  description = "Profile file within {option}`src` to install as the pack profile.";
+                };
+              };
+            }
+          );
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        home.packages = [ cfg.package ];
+
+        xdg.configFile =
+          lib.mapAttrs' (
+            name: value:
+            lib.nameValuePair "nono/profiles/${name}.json" {
+              source = jsonFormat.generate "nono-profile-${name}.json" value;
+            }
+          ) cfg.profiles
+          // lib.mapAttrs' (
+            ref: pack: lib.nameValuePair "nono/packages/${ref}" { source = mkPack ref pack; }
+          ) cfg.packs;
+      };
+    };
+}

--- a/modules/hosts/framework-13/bene-on-framework-13.nix
+++ b/modules/hosts/framework-13/bene-on-framework-13.nix
@@ -14,6 +14,7 @@
       home-manager.users.bene = {
         imports = with config.flake.modules.homeManager; [
           sway
+          ai-agent
           bitwarden
           calibre
           desktop-essentials

--- a/modules/users/user-base.nix
+++ b/modules/users/user-base.nix
@@ -10,6 +10,7 @@
       gpg
       git
       tools
+      nono
       ssh
       java-config
       catppuccin


### PR DESCRIPTION
## Summary

- Add a general-purpose `programs.nono` home-manager module for declaratively managing profiles (rendered via `pkgs.formats.json`) and on-disk registry packs, avoiding `nono pull`. Imported once in `user-base`, disabled by default.
- Add an `ai-agent` module that enables `programs.nono` with the opencode pack and `programs.opencode` with the ponytail plugin, both pinned via Nix. Imported only for `bene-on-framework-13`.

The opencode pack (`nolabs-ai/opencode`) and the ponytail opencode plugin (`DietrichGebert/ponytail`) are both fetched and pinned via `fetchFromGitHub` rather than downloaded at runtime, so `nono run --profile nolabs-ai/opencode` and the opencode plugin resolve from the Nix store.