### PR TITLE
desktop: add regreet greeter

### DIFF
--- a/modules/home/desktop/sway/regreet.nix
+++ b/modules/home/desktop/sway/regreet.nix
@@ -1,0 +1,49 @@
+{
+  flake.modules.nixos.regreet =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      # The programs.regreet module only wires up the cage launch. Run ReGreet
+      # under sway instead (more reliable than cage, and the compositor already
+      # used here). See ReGreet README "Set as default session".
+      greeterSwayConfig = pkgs.writeText "greetd-sway-config" ''
+        exec "${lib.getExe config.programs.regreet.package}; swaymsg exit"
+      '';
+    in
+    {
+      programs.regreet = {
+        enable = true;
+        theme = {
+          package = pkgs.catppuccin-gtk.override {
+            accents = [ "red" ]; # matches sway's $red borders
+            variant = "macchiato";
+          };
+          name = "catppuccin-macchiato-red-standard";
+        };
+        cursorTheme = {
+          package = pkgs.catppuccin-cursors.macchiatoDark;
+          name = "catppuccin-macchiato-dark-cursors";
+        };
+        font = {
+          package = pkgs.dejavu_fonts; # matches the sway UI font
+          name = "DejaVu Sans";
+          size = 12;
+        };
+        settings = {
+          background = {
+            path = "${pkgs.wallpapers}/landscapes/Clearday.jpg";
+            fit = "Cover";
+          };
+          GTK.application_prefer_dark_theme = true;
+        };
+      };
+
+      # Override the module's default cage launch with sway.
+      services.greetd.settings.default_session.command =
+        "${pkgs.dbus}/bin/dbus-run-session ${lib.getExe pkgs.sway} --config ${greeterSwayConfig}";
+    };
+}

--- a/modules/home/desktop/sway/sway.nix
+++ b/modules/home/desktop/sway/sway.nix
@@ -4,15 +4,12 @@ let
 in
 {
   flake.modules.nixos.sway =
-    { lib, pkgs, ... }:
+    { ... }:
     {
       imports = with outer.flake.modules.nixos; [
         noctalia
+        regreet
       ];
-
-      # puts systemd init logs on tty1
-      # so that tuigreet and systemd logs don't clobber each other
-      boot.kernelParams = [ "console=tty1" ];
 
       # xdg portal wlr is required for screensharing
       xdg.portal = {
@@ -22,17 +19,6 @@ in
       };
 
       services = {
-        greetd = {
-          enable = true;
-          useTextGreeter = true;
-          settings = {
-            default_session = {
-              # put on a single line to work around https://github.com/NixOS/nixpkgs/issues/527565
-              command = "${lib.getExe pkgs.tuigreet} --remember --time --asterisks --cmd ${lib.getExe pkgs.sway}";
-            };
-          };
-        };
-
         # Required for automatically mounting USB devices
         devmon.enable = true;
         gvfs.enable = true;


### PR DESCRIPTION
Replaces tuigreet, which often rendered incorrectly with a ReGreet, a
greetd greeter written in Rust.
