### PR TITLE
catppuccin: stop using catppuccin cursors

### DIFF
--- a/modules/home/catppuccin.nix
+++ b/modules/home/catppuccin.nix
@@ -1,19 +1,24 @@
 { inputs, ... }:
 {
-  flake.modules.homeManager.catppuccin = {
-    imports = [
-      inputs.catppuccin.homeModules.catppuccin
-    ];
+  flake.modules.homeManager.catppuccin =
+    { pkgs, ... }:
+    {
+      imports = [
+        inputs.catppuccin.homeModules.catppuccin
+      ];
 
-    catppuccin = {
-      autoEnable = true;
-      enable = true;
-      flavor = "macchiato";
-
-      cursors = {
+      catppuccin = {
+        autoEnable = true;
         enable = true;
-        accent = "dark";
+        flavor = "macchiato";
+      };
+
+      home.pointerCursor = {
+        enable = true;
+        package = pkgs.adwaita-icon-theme;
+        name = "Adwaita";
+        size = 32;
+        gtk.enable = true;
       };
     };
-  };
 }


### PR DESCRIPTION
They need to be built from source often which causes long
build times on CI and on framework-13.
