### PR TITLE
kotlin-lsp: 262.9593.0 -> 263.4421.0

### DIFF
--- a/packages/kotlin-lsp/default.nix
+++ b/packages/kotlin-lsp/default.nix
@@ -8,11 +8,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "kotlin-lsp";
-  version = "262.9593.0";
+  version = "263.4421.0";
 
   src = fetchzip {
     url = "https://download-cdn.jetbrains.com/language-server/kotlin-server/${finalAttrs.version}/kotlin-server-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-6ajvuyFga+IL9eLqNKCPphdVwRxpFQSQOy54HGreEqw=";
+    sha256 = "sha256-NI5hgLvganNwYP30fpeETpY5MLtvOOgpAjoNfyd1knA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Summary

262.9593.0 is an EAP build that expired on 2026-09-04. `intellij-server` now exits with "This build of intellij-server has expired", which fails the install check and breaks CI on main and on every open PR.

JetBrains published 263.4421.0 on the CDN but has not cut a GitHub release for it, see https://github.com/Kotlin/kotlin-lsp/issues/270.